### PR TITLE
Command decoupling with metadata

### DIFF
--- a/MonoZelda/Commands/CommandManager.cs
+++ b/MonoZelda/Commands/CommandManager.cs
@@ -36,9 +36,9 @@ public class CommandManager
         AddCommand(CommandType.LoadRoomCommand, new LoadRoomCommand());
     }
 
-    public void Execute(CommandType commandType, Keys PressedKey)
+    public void Execute(CommandType commandType, params object[] metadata)
     {
-        commandMap[commandType].Execute(PressedKey);
+        commandMap[commandType].Execute(metadata);
     }
 
     public bool ReplaceCommand(CommandType commandType, ICommand command)

--- a/MonoZelda/Commands/CommandManager.cs
+++ b/MonoZelda/Commands/CommandManager.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
-using Microsoft.Xna.Framework.Input;
 using MonoZelda.Commands;
-using PixelPushers.MonoZelda.Controllers;
 
 namespace PixelPushers.MonoZelda.Commands;
 

--- a/MonoZelda/Commands/ExitCommand.cs
+++ b/MonoZelda/Commands/ExitCommand.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Xna.Framework.Input;
-
-namespace PixelPushers.MonoZelda.Commands;
+﻿namespace PixelPushers.MonoZelda.Commands;
 
 public class ExitCommand : ICommand
 {

--- a/MonoZelda/Commands/ExitCommand.cs
+++ b/MonoZelda/Commands/ExitCommand.cs
@@ -16,7 +16,7 @@ public class ExitCommand : ICommand
         this.game = game;
     }
 
-    public void Execute(Keys PressedKey)
+    public void Execute(params object[] metadata)
     {
         game.Exit();
     }

--- a/MonoZelda/Commands/ICommand.cs
+++ b/MonoZelda/Commands/ICommand.cs
@@ -4,6 +4,6 @@ namespace PixelPushers.MonoZelda.Commands;
 
 public interface ICommand
 {
-    void Execute(Keys PressedKey);
+    void Execute(params object[] metadata);
     void UnExecute();
 }

--- a/MonoZelda/Commands/LoadRoomCommand.cs
+++ b/MonoZelda/Commands/LoadRoomCommand.cs
@@ -2,8 +2,6 @@
 using MonoZelda.Dungeons;
 using PixelPushers.MonoZelda;
 using PixelPushers.MonoZelda.Commands;
-using PixelPushers.MonoZelda.Controllers;
-using System.Numerics;
 
 namespace MonoZelda.Commands
 {
@@ -11,8 +9,6 @@ namespace MonoZelda.Commands
     {
         private MonoZeldaGame game;
         private IDungeonRoom room;
-
-        public MouseState MouseState {get;set;}
 
         public LoadRoomCommand() { }
 
@@ -22,8 +18,9 @@ namespace MonoZelda.Commands
             this.room = room;
         }
 
-        public void Execute(Keys PressedKey)
+        public void Execute(params object[] metadata)
         {
+            MouseState mouseState = (MouseState) metadata[0];
             if(room == null || game == null)
             {
                 return;
@@ -33,11 +30,10 @@ namespace MonoZelda.Commands
             var doors = room.GetDoors();
 
             // CommandManager dosn't expose a method to get commands, so we can't assign this in the mouse controller
-            MouseState = Mouse.GetState();
 
             foreach (var door in doors)
             {
-                if (door.Bounds.Contains(MouseState.X, MouseState.Y) && !string.IsNullOrEmpty(door.Destination))
+                if (door.Bounds.Contains(mouseState.X, mouseState.Y) && !string.IsNullOrEmpty(door.Destination))
                 {
                     game.LoadDungeon(door.Destination);
                     return;

--- a/MonoZelda/Commands/PlayerAttackCommand.cs
+++ b/MonoZelda/Commands/PlayerAttackCommand.cs
@@ -17,7 +17,7 @@ public class PlayerAttackCommand : ICommand
         this.player = player;
     }
 
-    public void Execute(Keys PressedKey)
+    public void Execute(params object[] metadata)
     {
         player?.Attack();
     }

--- a/MonoZelda/Commands/PlayerAttackCommand.cs
+++ b/MonoZelda/Commands/PlayerAttackCommand.cs
@@ -1,5 +1,4 @@
 ﻿using PixelPushers.MonoZelda.Link;
-using Microsoft.Xna.Framework.Input;
 
 namespace PixelPushers.MonoZelda.Commands;
 

--- a/MonoZelda/Commands/PlayerMoveCommand.cs
+++ b/MonoZelda/Commands/PlayerMoveCommand.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Xna.Framework;
-using PixelPushers.MonoZelda.Link;
+﻿using PixelPushers.MonoZelda.Link;
 using Microsoft.Xna.Framework.Input;
 
 namespace PixelPushers.MonoZelda.Commands;

--- a/MonoZelda/Commands/PlayerMoveCommand.cs
+++ b/MonoZelda/Commands/PlayerMoveCommand.cs
@@ -21,8 +21,9 @@ public class PlayerMoveCommand : ICommand
 
     public Direction PlayerDirection { get; private set; }
 
-    public void Execute(Keys pressedKey)
+    public void Execute(params object[] metadata)
     {
+        Keys pressedKey = (Keys) metadata[0];
         SetPlayerDirection(pressedKey);
         player?.Move(this);
     }

--- a/MonoZelda/Commands/PlayerStandingCommand.cs
+++ b/MonoZelda/Commands/PlayerStandingCommand.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using PixelPushers.MonoZelda.Link;
-using Microsoft.Xna.Framework.Input;
+﻿using PixelPushers.MonoZelda.Link;
 
 namespace PixelPushers.MonoZelda.Commands
 {

--- a/MonoZelda/Commands/PlayerStandingCommand.cs
+++ b/MonoZelda/Commands/PlayerStandingCommand.cs
@@ -18,7 +18,7 @@ namespace PixelPushers.MonoZelda.Commands
             this.player = player;   
         }
 
-        public void Execute(Keys PressedKey)
+        public void Execute(params object[] metadata)
         {
             // call player standing method
             if (player != null)

--- a/MonoZelda/Commands/PlayerTakeDamageCommand.cs
+++ b/MonoZelda/Commands/PlayerTakeDamageCommand.cs
@@ -1,5 +1,4 @@
 ﻿using PixelPushers.MonoZelda.Link;
-using Microsoft.Xna.Framework.Input;
 
 namespace PixelPushers.MonoZelda.Commands;
 

--- a/MonoZelda/Commands/PlayerTakeDamageCommand.cs
+++ b/MonoZelda/Commands/PlayerTakeDamageCommand.cs
@@ -17,7 +17,7 @@ public class PlayerTakeDamageCommand : ICommand
         this.player = player;
     }
 
-    public void Execute(Keys PressedKey)
+    public void Execute(params object[] metadata)
     {
         if (player == null)
             return;

--- a/MonoZelda/Commands/PlayerUseItemCommand.cs
+++ b/MonoZelda/Commands/PlayerUseItemCommand.cs
@@ -30,12 +30,13 @@ public class PlayerUseItemCommand : ICommand
         projectiles.EnableDict();
     }
 
-    public void Execute(Keys PressedKey)
+    public void Execute(params object[] metadata)
     {
+        Keys pressedKey = (Keys) metadata[0];
         // create projectile
         if(!projectileManager.ProjectileFired)
         {
-            CreateProjectile(PressedKey);
+            CreateProjectile(pressedKey);
         }
 
         // animate player throw projectile

--- a/MonoZelda/Commands/ResetCommand.cs
+++ b/MonoZelda/Commands/ResetCommand.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Xna.Framework.Input;
-
-namespace PixelPushers.MonoZelda.Commands;
+﻿namespace PixelPushers.MonoZelda.Commands;
 
 public class ResetCommand : ICommand
 {

--- a/MonoZelda/Commands/ResetCommand.cs
+++ b/MonoZelda/Commands/ResetCommand.cs
@@ -16,7 +16,7 @@ public class ResetCommand : ICommand
         this.game = game;
     }
 
-    public void Execute(Keys PressedKey)
+    public void Execute(params object[] metadata)
     {
         game?.GetCollisionController().Reset();
         game?.StartMenu();

--- a/MonoZelda/Commands/StartGameCommand.cs
+++ b/MonoZelda/Commands/StartGameCommand.cs
@@ -16,7 +16,7 @@ public class StartGameCommand : ICommand
         this.game = game;
     }
 
-    public void Execute(Keys PressedKey)
+    public void Execute(params object[] metadata)
     {
         game?.StartDungeon();
     }

--- a/MonoZelda/Commands/StartGameCommand.cs
+++ b/MonoZelda/Commands/StartGameCommand.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Xna.Framework.Input;
-
-namespace PixelPushers.MonoZelda.Commands;
+﻿namespace PixelPushers.MonoZelda.Commands;
 
 public class StartGameCommand : ICommand
 {

--- a/MonoZelda/Controllers/CollisionController.cs
+++ b/MonoZelda/Controllers/CollisionController.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using PixelPushers.MonoZelda.Commands;
 using Microsoft.Xna.Framework;
-using System;
 using MonoZelda.Collision;
 
 namespace PixelPushers.MonoZelda.Controllers;

--- a/MonoZelda/Controllers/IController.cs
+++ b/MonoZelda/Controllers/IController.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 
 namespace PixelPushers.MonoZelda.Controllers;
 

--- a/MonoZelda/Controllers/KeyboardController.cs
+++ b/MonoZelda/Controllers/KeyboardController.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using PixelPushers.MonoZelda.Commands;
-using System;
 using System.Collections.Generic;
 
 namespace PixelPushers.MonoZelda.Controllers;

--- a/MonoZelda/Controllers/MouseController.cs
+++ b/MonoZelda/Controllers/MouseController.cs
@@ -24,7 +24,7 @@ public class MouseController : IController
         // Mouse input logic goes here
         if (OneShotPressed(MouseButton.Left))
         {
-            _commandManager.Execute(CommandType.LoadRoomCommand, Keys.None);
+            _commandManager.Execute(CommandType.LoadRoomCommand, CurrentMouseState);
         }
 
         PreviousMouseState = CurrentMouseState;


### PR DESCRIPTION
This updates commands to allow metadata to be passed along with a command. This decouples the controller from the commands in multiple places. It will also decouple collision metadata from the collision controller in the future.