### PR TITLE
Spawn Link in Correct Position, Player Static Block Collision

### DIFF
--- a/MonoZelda/Commands/CollisionCommands/PlayerStaticCollisionCommand.cs
+++ b/MonoZelda/Commands/CollisionCommands/PlayerStaticCollisionCommand.cs
@@ -1,22 +1,52 @@
-﻿namespace MonoZelda.Commands.CollisionCommands;
+﻿using Microsoft.Xna.Framework;
+using MonoZelda.Collision;
+using MonoZelda.Controllers;
+using MonoZelda.Link;
+using System.Diagnostics;
+
+namespace MonoZelda.Commands.CollisionCommands;
 
 public class PlayerStaticCollisionCommand : ICommand
 {
     private MonoZeldaGame game;
-
+    private Player player;
     public PlayerStaticCollisionCommand()
     {
         //empty
     }
 
-    public PlayerStaticCollisionCommand(MonoZeldaGame game)
+    public PlayerStaticCollisionCommand(Player player)
     {
-        this.game = game;
+        this.player = player;
     }
 
     public void Execute(params object[] metadata)
     {
-        // ADD EXECUTE LOGIC HERE
+        Collidable collidableA = (Collidable)metadata[0];
+        Collidable collidableB = (Collidable)metadata[1];
+        CollisionController collisionController = (CollisionController)metadata[2];
+        Direction collisionDirection = (Direction)metadata[3];
+        Rectangle intersection = (Rectangle)metadata[4];
+
+        Vector2 currentPos = player.GetPlayerPosition();
+
+        switch (collisionDirection)
+        {
+            case Direction.Left:
+                currentPos.X -= intersection.Width;
+                break;
+            case Direction.Right:
+                currentPos.X += intersection.Width;
+                break;
+            case Direction.Up:
+                currentPos.Y -= intersection.Height;
+                break;
+            case Direction.Down:
+                currentPos.Y += intersection.Height;
+                break;
+        }
+
+        player.SetPosition(currentPos);
     }
 
     public void UnExecute()

--- a/MonoZelda/Link/Player.cs
+++ b/MonoZelda/Link/Player.cs
@@ -21,7 +21,7 @@ public class Player
 
     public Player()
     {
-        playerPostition = new Vector2(100, 100);
+        playerPostition = new Vector2(500, 500);
     }
 
     public void SetPlayerSpriteDict(SpriteDict spriteDict)
@@ -187,6 +187,11 @@ public class Player
     public Vector2 GetPlayerPosition()
     {
         return playerPostition;
+    }
+    public void SetPosition(Vector2 position)
+    {
+        playerPostition = position;
+        playerSpriteDict.Position = position.ToPoint();
     }
 
 }

--- a/MonoZelda/MonoZeldaGame.cs
+++ b/MonoZelda/MonoZeldaGame.cs
@@ -73,8 +73,8 @@ public class MonoZeldaGame : Game
     {
         keyboardController.Update(gameTime);
         mouseController.Update(gameTime);
-        collisionController.Update(gameTime);
         scene.Update(gameTime);
+        collisionController.Update(gameTime);
 
         base.Update(gameTime);
     }

--- a/MonoZelda/Scenes/DungeonScene.cs
+++ b/MonoZelda/Scenes/DungeonScene.cs
@@ -10,6 +10,7 @@ using MonoZelda.Controllers;
 using MonoZelda.Dungeons;
 using MonoZelda.Items;
 using MonoZelda.Commands.GameCommands;
+using MonoZelda.Commands.CollisionCommands;
 
 namespace MonoZelda.Scenes;
 
@@ -57,6 +58,7 @@ public class DungeonScene : IScene
         commandManager.ReplaceCommand(CommandType.PlayerStandingCommand, new PlayerStandingCommand(player));
         commandManager.ReplaceCommand(CommandType.PlayerUseItemCommand, new PlayerUseItemCommand(projectiles, projectileManager, player));
         commandManager.ReplaceCommand(CommandType.PlayerTakeDamageCommand, new PlayerTakeDamageCommand(player));
+        commandManager.ReplaceCommand(CommandType.PlayerStaticCollisionCommand, new PlayerStaticCollisionCommand(player));
 
         // create spritedict to pass into player controller
         var playerSpriteDict = new SpriteDict(contentManager.Load<Texture2D>(TextureData.Player), SpriteCSVData.Player, 1, new Point(100, 100));


### PR DESCRIPTION
There is a "bug" that I will add to backlog to be resolved. When player collides with two collidables at once there is a gittering effect. 