### PR TITLE
Calvin enemy stun/damage + extras

### DIFF
--- a/MonoZelda/Commands/CollisionCommands/EnemyPlayerProjectileCollisionCommand.cs
+++ b/MonoZelda/Commands/CollisionCommands/EnemyPlayerProjectileCollisionCommand.cs
@@ -1,6 +1,8 @@
-﻿using MonoZelda.Collision;
+﻿using System;
+using MonoZelda.Collision;
 using MonoZelda.Controllers;
 using MonoZelda.Enemies;
+using MonoZelda.Link.Projectiles;
 
 namespace MonoZelda.Commands.CollisionCommands;
 
@@ -20,6 +22,7 @@ public class EnemyPlayerProjectileCollisionCommand : ICommand
 
         PlayerProjectileCollidable projectileCollidable;
         EnemyCollidable enemyCollidable;
+        Boolean stun = false;
 
         if (collidableA.type == CollidableType.PlayerProjectile)
         {
@@ -36,9 +39,15 @@ public class EnemyPlayerProjectileCollisionCommand : ICommand
         {
             projectileCollidable.ProjectileManager.destroyProjectile();
         }
+
+        if (projectileCollidable.projectileType == ProjectileType.Boomerang ||
+            projectileCollidable.projectileType == ProjectileType.BoomerangBlue)
+        {
+            stun = true;
+        }
+        collisionController.RemoveCollidable(projectileCollidable);
         IEnemy enemy = enemyCollidable.getEnemy();
-        enemy.KillEnemy();
-        collisionController.RemoveCollidable(enemyCollidable);
+        enemy.TakeDamage(stun);
     }
 
     public void UnExecute()

--- a/MonoZelda/Commands/CollisionCommands/EnemyPlayerProjectileCollisionCommand.cs
+++ b/MonoZelda/Commands/CollisionCommands/EnemyPlayerProjectileCollisionCommand.cs
@@ -2,6 +2,7 @@
 using MonoZelda.Collision;
 using MonoZelda.Controllers;
 using MonoZelda.Enemies;
+using MonoZelda.Link;
 using MonoZelda.Link.Projectiles;
 
 namespace MonoZelda.Commands.CollisionCommands;
@@ -19,6 +20,7 @@ public class EnemyPlayerProjectileCollisionCommand : ICommand
         ICollidable collidableA = (ICollidable)metadata[0];
         ICollidable collidableB = (ICollidable)metadata[1];
         CollisionController collisionController = (CollisionController)metadata[2];
+        Direction collisionDirection = (Direction)metadata[3];
 
         PlayerProjectileCollidable projectileCollidable;
         EnemyCollidable enemyCollidable;
@@ -47,7 +49,7 @@ public class EnemyPlayerProjectileCollisionCommand : ICommand
         }
         collisionController.RemoveCollidable(projectileCollidable);
         IEnemy enemy = enemyCollidable.getEnemy();
-        enemy.TakeDamage(stun);
+        enemy.TakeDamage(stun, collisionDirection);
     }
 
     public void UnExecute()

--- a/MonoZelda/Commands/CollisionCommands/EnemyProjectileStaticBoundaryCollisionCommand.cs
+++ b/MonoZelda/Commands/CollisionCommands/EnemyProjectileStaticBoundaryCollisionCommand.cs
@@ -1,0 +1,42 @@
+﻿using MonoZelda.Collision;
+using MonoZelda.Controllers;
+using MonoZelda.Enemies;
+using MonoZelda.Enemies.EnemyProjectiles;
+using MonoZelda.Link;
+
+namespace MonoZelda.Commands.CollisionCommands;
+
+public class EnemyProjectileStaticBoundaryCollisionCommand : ICommand
+{
+    private MonoZeldaGame game;
+
+    public EnemyProjectileStaticBoundaryCollisionCommand()
+    {
+        //empty
+    }
+    public void Execute(params object[] metadata)
+    {
+        ICollidable collidableA = (ICollidable)metadata[0];
+        ICollidable collidableB = (ICollidable)metadata[1];
+        CollisionController collisionController = (CollisionController)metadata[2];
+
+        EnemyProjectileCollidable enemyProjectileCollidable;
+
+        if (collidableA.type == CollidableType.PlayerProjectile)
+        {
+            enemyProjectileCollidable = (EnemyProjectileCollidable)collidableA;
+        }
+        else
+        {
+            enemyProjectileCollidable = (EnemyProjectileCollidable)collidableB;
+        }
+        EnemyProjectileCollisionManager enemyProjectileCollision = enemyProjectileCollidable.EnemyProjectileCollision;
+
+        enemyProjectileCollision.HandleCollision();
+    }
+
+    public void UnExecute()
+    {
+        //empty
+    }
+}

--- a/MonoZelda/Commands/CollisionCommands/PlayerEnemyProjectileCollisionCommand.cs
+++ b/MonoZelda/Commands/CollisionCommands/PlayerEnemyProjectileCollisionCommand.cs
@@ -40,7 +40,7 @@ public class PlayerEnemyProjectileCollisionCommand : ICommand
         PlayerCollisionManager playerCollision = playerCollidable.PlayerCollision;
 
         playerCollision.HandleEnemyProjectileCollision(collisionDirection);
-        //enemyProjectileCollision.DestroyProjectile();
+        enemyProjectileCollision.HandleCollision();
     }
     public void UnExecute()
     {

--- a/MonoZelda/Commands/CommandManager.cs
+++ b/MonoZelda/Commands/CommandManager.cs
@@ -26,6 +26,7 @@ public enum CommandType
     EnemyPlayerProjectileCollisionCommand,
     EnemyStaticRoomCollisionCommand,
     EnemyStaticBoundaryCollisionCommand,
+    EnemyProjectileStaticBoundaryCollisionCommand,
     PlayerProjectileStaticRoomCollisionCommand,
     PlayerProjectileStaticBoundaryCollisionCommand,
     ToggleGizmosCommand,
@@ -56,6 +57,8 @@ public class CommandManager
         AddCommand(CommandType.EnemyPlayerProjectileCollisionCommand, new EnemyPlayerProjectileCollisionCommand());
         AddCommand(CommandType.EnemyStaticRoomCollisionCommand, new EnemyStaticRoomCollisionCommand());
         AddCommand(CommandType.EnemyStaticBoundaryCollisionCommand, new EnemyStaticBoundaryCollisionCommand());
+        AddCommand(CommandType.EnemyProjectileStaticBoundaryCollisionCommand,
+            new EnemyProjectileStaticBoundaryCollisionCommand());
         AddCommand(CommandType.PlayerProjectileStaticRoomCollisionCommand, new PlayerProjectileStaticRoomCollisionCommand());
         AddCommand(CommandType.PlayerProjectileStaticBoundaryCollisionCommand, new PlayerProjectileStaticBoundaryCollisionCommand());
         AddCommand(CommandType.ToggleGizmosCommand, new ToggleGizmosCommand());

--- a/MonoZelda/Controllers/CollisionController.cs
+++ b/MonoZelda/Controllers/CollisionController.cs
@@ -29,6 +29,7 @@ public class CollisionController : IController
             {(CollidableType.Enemy, CollidableType.PlayerProjectile), CommandType.EnemyPlayerProjectileCollisionCommand},
             {(CollidableType.Enemy, CollidableType.StaticRoom), CommandType.EnemyStaticRoomCollisionCommand},
             {(CollidableType.Enemy, CollidableType.StaticBoundary), CommandType.EnemyStaticBoundaryCollisionCommand},
+            {(CollidableType.EnemyProjectile, CollidableType.StaticBoundary), CommandType.EnemyProjectileStaticBoundaryCollisionCommand},
             {(CollidableType.PlayerProjectile, CollidableType.StaticRoom), CommandType.PlayerProjectileStaticRoomCollisionCommand},
             {(CollidableType.PlayerProjectile, CollidableType.StaticBoundary), CommandType.PlayerProjectileStaticBoundaryCollisionCommand},
         };

--- a/MonoZelda/Enemies/CardinalEnemyStateMachine.cs
+++ b/MonoZelda/Enemies/CardinalEnemyStateMachine.cs
@@ -51,7 +51,7 @@ namespace MonoZelda.Enemies
             enemySpriteDict.SetSprite("death");
         }
 
-        public Point Update(Point position, GameTime gameTime)
+        public Point Update(IEnemy enemy, Point position, GameTime gameTime)
         {
             dt = (float)gameTime.ElapsedGameTime.TotalSeconds;
             Vector2 enemyPosition = position.ToVector2();
@@ -60,6 +60,7 @@ namespace MonoZelda.Enemies
                 animationTimer = animationTimer + dt;
                 if (animationTimer >= 1)
                 {
+                    enemy.ChangeDirection();
                     spawning = false;
                 }
             }
@@ -69,6 +70,7 @@ namespace MonoZelda.Enemies
                 if (animationTimer >= 0.5)
                 {
                     enemySpriteDict.Enabled = false;
+                    enemy.Alive = false;
                 }
             }
             else

--- a/MonoZelda/Enemies/CardinalEnemyStateMachine.cs
+++ b/MonoZelda/Enemies/CardinalEnemyStateMachine.cs
@@ -1,20 +1,42 @@
 ﻿using Microsoft.Xna.Framework;
+using MonoZelda.Sprites;
 
 namespace MonoZelda.Enemies
 {
     public class CardinalEnemyStateMachine
     {
+        //states
         public enum Direction { Left, Right, Up, Down, None }
-
         private Direction direction = Direction.None;
+        private bool spawning;
+        public bool Dead { get; set; }
 
-        private int velocity = 1;
-
+        //not states
+        private float velocity = 60;
+        private float dt;
+        private double animationTimer;
+        private SpriteDict enemySpriteDict;
+        private string currentSprite;
+        private Vector2 movement;
         public Point currentPosition { get; private set; }
+
+        public CardinalEnemyStateMachine(SpriteDict spriteDict)
+        {
+            enemySpriteDict = spriteDict;
+            spawning = true;
+            Dead = false;
+            animationTimer = 0;
+            enemySpriteDict.SetSprite("cloud");
+        }
       
         public void ChangeDirection(Direction newDirection)
         {
             direction = newDirection;
+        }
+
+        public void SetSprite(string newSprite)
+        {
+            currentSprite = newSprite;
         }
 
         public void ChangeSpeed(int newSpeed)
@@ -22,23 +44,49 @@ namespace MonoZelda.Enemies
             velocity = newSpeed;
         }
 
-        public Point Update(Point position)
+        public void Die()
         {
-            switch (direction)
+            Dead = true;
+            animationTimer = 0;
+            enemySpriteDict.SetSprite("death");
+        }
+
+        public Point Update(Point position, GameTime gameTime)
+        {
+            dt = (float)gameTime.ElapsedGameTime.TotalSeconds;
+            Vector2 enemyPosition = position.ToVector2();
+            if (spawning)
             {
-                case Direction.Left:
-                    position.X -= velocity;
-                    break;
-                case Direction.Right:
-                    position.X += velocity;
-                    break;
-                case Direction.Up:
-                    position.Y -= velocity;
-                    break;
-                case Direction.Down:
-                    position.Y += velocity;
-                    break;
+                animationTimer = animationTimer + dt;
+                if (animationTimer >= 1)
+                {
+                    spawning = false;
+                }
             }
+            else if (Dead)
+            {
+                animationTimer = animationTimer + dt;
+                if (animationTimer >= 0.5)
+                {
+                    enemySpriteDict.Enabled = false;
+                }
+            }
+            else
+            {
+                movement = direction switch
+                {
+                    Direction.Up => new Vector2(0, -1),
+                    Direction.Down => new Vector2(0, 1),
+                    Direction.Left => new Vector2(-1, 0),
+                    Direction.Right => new Vector2(1, 0),
+                    _ => Vector2.Zero
+                };
+                enemyPosition += (velocity * movement)*dt;
+                enemySpriteDict.SetSprite(currentSprite);
+            }
+
+            position = enemyPosition.ToPoint();
+            enemySpriteDict.Position = position;
             currentPosition = position;
             return position;
         }

--- a/MonoZelda/Enemies/EnemyClasses/Aquamentus.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Aquamentus.cs
@@ -16,6 +16,7 @@ namespace MonoZelda.Enemies.EnemyClasses
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
+        public bool Alive { get; set; }
         private CardinalEnemyStateMachine stateMachine;
         private readonly Random rnd = new();
         private SpriteDict aquamentusSpriteDict;
@@ -57,7 +58,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             aquamentusSpriteDict = enemyDict;
             Pos = spawnPosition;
             pixelsMoved = 0;
-            stateMachine = new CardinalEnemyStateMachine();
+            stateMachine = new CardinalEnemyStateMachine(enemyDict);
             stateMachine.ChangeDirection(CardinalEnemyStateMachine.Direction.Left);
             fireballs.Add(new AquamentusFireball(spawnPosition, contentManager, graphicsDevice, collisionController, midAngle + 45));
             fireballs.Add(new AquamentusFireball(spawnPosition, contentManager, graphicsDevice, collisionController, midAngle));
@@ -96,7 +97,7 @@ namespace MonoZelda.Enemies.EnemyClasses
 
         public void Update(GameTime gameTime)
         {
-            Pos = stateMachine.Update(Pos);
+            Pos = stateMachine.Update(Pos, gameTime);
             aquamentusSpriteDict.Position = Pos;
             pixelsMoved++;
             if (Pos.X > spawnPoint.X || Pos.X < spawnPoint.X - tileSize*5)
@@ -135,7 +136,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             }
         }
 
-        public void KillEnemy()
+        public void TakeDamage(Boolean stun)
         {
             // not implemented
         }

--- a/MonoZelda/Enemies/EnemyClasses/Aquamentus.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Aquamentus.cs
@@ -97,7 +97,7 @@ namespace MonoZelda.Enemies.EnemyClasses
 
         public void Update(GameTime gameTime)
         {
-            Pos = stateMachine.Update(Pos, gameTime);
+            Pos = stateMachine.Update(this, Pos, gameTime);
             aquamentusSpriteDict.Position = Pos;
             pixelsMoved++;
             if (Pos.X > spawnPoint.X || Pos.X < spawnPoint.X - tileSize*5)

--- a/MonoZelda/Enemies/EnemyClasses/Aquamentus.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Aquamentus.cs
@@ -7,6 +7,7 @@ using MonoZelda.Collision;
 using MonoZelda.Controllers;
 using MonoZelda.Enemies.EnemyProjectiles;
 using Microsoft.Xna.Framework.Graphics;
+using MonoZelda.Link;
 
 namespace MonoZelda.Enemies.EnemyClasses
 {
@@ -136,7 +137,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             }
         }
 
-        public void TakeDamage(Boolean stun)
+        public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
             // not implemented
         }

--- a/MonoZelda/Enemies/EnemyClasses/Aquamentus.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Aquamentus.cs
@@ -18,68 +18,67 @@ namespace MonoZelda.Enemies.EnemyClasses
         public int Width { get; set; }
         public int Height { get; set; }
         public bool Alive { get; set; }
-        private CardinalEnemyStateMachine stateMachine;
+        private EnemyStateMachine stateMachine;
         private readonly Random rnd = new();
-        private SpriteDict aquamentusSpriteDict;
         private readonly GraphicsDevice graphicsDevice;
-        private CardinalEnemyStateMachine.Direction direction = CardinalEnemyStateMachine.Direction.Left;
+        private EnemyStateMachine.Direction direction = EnemyStateMachine.Direction.Left;
+        private CollisionController collisionController;
+        private ContentManager contentManager;
 
         private List<IEnemyProjectile> fireballs = new();
         private Dictionary<IEnemyProjectile, EnemyProjectileCollisionManager> projectileDictionary = new();
         private int midAngle = 180;
-
+        private int health = 6;
         private Point spawnPoint;
         private int pixelsMoved;
         private int tileSize = 64;
         private int moveDelay;
         private double attackDelay;
+        private double dt;
         private bool projectileActive;
 
         public Aquamentus(GraphicsDevice graphicsDevice)
         {
             this.graphicsDevice = graphicsDevice;
-            projectileActive = true;
+            projectileActive = false;
             pixelsMoved = 0;
             moveDelay = rnd.Next(1, 4);
             attackDelay = 0;
-            Width = 92;
-            Height = 92;
+            Width = 32;
+            Height = 84;
+            Alive = true;
 
         }
 
         public void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController,
             ContentManager contentManager)
         {
+            this.collisionController = collisionController;
+            this.contentManager = contentManager;
             spawnPoint = spawnPosition;
-            EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, 60, 60), graphicsDevice, EnemyList.Aquamentus);
+            EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), graphicsDevice, EnemyList.Aquamentus);
             collisionController.AddCollidable(EnemyHitbox);
             EnemyHitbox.setSpriteDict(enemyDict);
             enemyDict.Position = spawnPosition;
-            enemyDict.SetSprite("aquamentus_left");
-            aquamentusSpriteDict = enemyDict;
             Pos = spawnPosition;
             pixelsMoved = 0;
-            stateMachine = new CardinalEnemyStateMachine(enemyDict);
-            stateMachine.ChangeDirection(CardinalEnemyStateMachine.Direction.Left);
-            fireballs.Add(new AquamentusFireball(spawnPosition, contentManager, graphicsDevice, collisionController, midAngle + 45));
-            fireballs.Add(new AquamentusFireball(spawnPosition, contentManager, graphicsDevice, collisionController, midAngle));
-            fireballs.Add(new AquamentusFireball(spawnPosition, contentManager, graphicsDevice, collisionController, midAngle - 45));
-            foreach (var projectile in fireballs)
-            {
-                projectileDictionary.Add(projectile, new EnemyProjectileCollisionManager(projectile, collisionController));
-            }
+            stateMachine = new EnemyStateMachine(enemyDict);
+            stateMachine.SetSprite("aquamentus_left");
+            stateMachine.ChangeDirection(EnemyStateMachine.Direction.Left);
+            stateMachine.Spawning = false;
+            stateMachine.ChangeSpeed(60);
         }
 
         public void ChangeDirection()
         {
             switch (direction)
             {
-                case CardinalEnemyStateMachine.Direction.Left:
-                    direction = CardinalEnemyStateMachine.Direction.Right;
+                case EnemyStateMachine.Direction.Left:
+                    direction = EnemyStateMachine.Direction.Right;
                     stateMachine.ChangeDirection(direction);
                     break;
-                case CardinalEnemyStateMachine.Direction.Right:
-                    direction = CardinalEnemyStateMachine.Direction.Left;
+                case EnemyStateMachine.Direction.Right:
+                    direction = EnemyStateMachine.Direction.Left;
                     stateMachine.ChangeDirection(direction);
                     break;
             }
@@ -87,21 +86,42 @@ namespace MonoZelda.Enemies.EnemyClasses
 
         public void Attack(GameTime gameTime)
         {
-            fireballs.ForEach(fireball => fireball.ViewProjectile(projectileActive, true));
-            fireballs.ForEach(fireball => fireball.Update(gameTime, CardinalEnemyStateMachine.Direction.Left, Pos));
-            if (gameTime.TotalGameTime.TotalSeconds >= attackDelay + 4)
+            fireballs.ForEach(fireball => fireball.Update(gameTime, EnemyStateMachine.Direction.Left, Pos));
+            if (attackDelay >= 6)
             {
-                fireballs.ForEach(fireball => fireball.Follow(Pos));
-                attackDelay = gameTime.TotalGameTime.TotalSeconds;
+                fireballs.RemoveRange(0,2);
+                foreach (var entry in projectileDictionary)
+                {
+                    projectileDictionary.Remove(entry.Key);
+                }
+
+                projectileActive = false;
+                attackDelay = 0;
+            }
+        }
+
+        public void CreateFireballs()
+        {
+            if (!projectileActive)
+            {
+                projectileActive = true;
+                fireballs.Add(new AquamentusFireball(Pos, contentManager, graphicsDevice, collisionController, midAngle + 45));
+                fireballs.Add(new AquamentusFireball(Pos, contentManager, graphicsDevice, collisionController, midAngle));
+                fireballs.Add(new AquamentusFireball(Pos, contentManager, graphicsDevice, collisionController, midAngle - 45));
+                foreach (var projectile in fireballs)
+                {
+                    projectileDictionary.Add(projectile, new EnemyProjectileCollisionManager(projectile, collisionController));
+                }
             }
         }
 
         public void Update(GameTime gameTime)
         {
+            dt = gameTime.ElapsedGameTime.TotalSeconds;
+            attackDelay += dt;
             Pos = stateMachine.Update(this, Pos, gameTime);
-            aquamentusSpriteDict.Position = Pos;
             pixelsMoved++;
-            if (Pos.X > spawnPoint.X || Pos.X < spawnPoint.X - tileSize*5)
+            if (Pos.X > spawnPoint.X + 10 || Pos.X < spawnPoint.X - tileSize*5 - 10)
             {
                 ChangeDirection();
                 pixelsMoved = 0;
@@ -116,16 +136,16 @@ namespace MonoZelda.Enemies.EnemyClasses
                 }
             }
 
-            if (gameTime.TotalGameTime.TotalSeconds >= attackDelay)
+            if (attackDelay >= 3)
             {
-                if (gameTime.TotalGameTime.TotalSeconds <= attackDelay + 0.1)
+                if (attackDelay <= 3.1)
                 {
-                    fireballs.ForEach(fireball => fireball.Follow(Pos));
-                    aquamentusSpriteDict.SetSprite("aquamentus_left_mouthopen");
+                    CreateFireballs();
+                    stateMachine.SetSprite("aquamentus_left_mouthopen");
                 }
-                else if (gameTime.TotalGameTime.TotalSeconds >= attackDelay + 0.5)
+                else
                 {
-                    aquamentusSpriteDict.SetSprite("aquamentus_left");
+                    stateMachine.SetSprite("aquamentus_left");
                 }
 
                 Attack(gameTime);
@@ -139,7 +159,17 @@ namespace MonoZelda.Enemies.EnemyClasses
 
         public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
-            // not implemented
+            if (!stun)
+            {
+                health--;
+                if (health == 0)
+                {
+                    fireballs.ForEach(fireball => fireball.ProjectileCollide());
+                    stateMachine.Die();
+                    EnemyHitbox.UnregisterHitbox();
+                    collisionController.RemoveCollidable(EnemyHitbox);
+                }
+            }
         }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Dodongo.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Dodongo.cs
@@ -20,6 +20,7 @@ namespace MonoZelda.Enemies.EnemyClasses
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
+        public bool Alive { get; set; }
 
         private int tileSize = 64;
 
@@ -41,7 +42,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             dodongoSpriteDict.SetSprite("cloud");
             Pos = spawnPosition;
             pixelsMoved = 0;
-            stateMachine = new CardinalEnemyStateMachine();
+            stateMachine = new CardinalEnemyStateMachine(enemyDict);
         }
 
         public void ChangeDirection()
@@ -82,12 +83,12 @@ namespace MonoZelda.Enemies.EnemyClasses
             else
             {
                 pixelsMoved++;
-                Pos = stateMachine.Update(Pos);
+                Pos = stateMachine.Update(Pos, gameTime);
                 dodongoSpriteDict.Position = Pos;
             }
         }
 
-        public void KillEnemy()
+        public void TakeDamage(Boolean stun)
         {
             dodongoSpriteDict.Enabled = false;
             EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyClasses/Dodongo.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Dodongo.cs
@@ -83,7 +83,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             else
             {
                 pixelsMoved++;
-                Pos = stateMachine.Update(Pos, gameTime);
+                Pos = stateMachine.Update(this, Pos, gameTime);
                 dodongoSpriteDict.Position = Pos;
             }
         }

--- a/MonoZelda/Enemies/EnemyClasses/Dodongo.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Dodongo.cs
@@ -11,18 +11,19 @@ namespace MonoZelda.Enemies.EnemyClasses
 {
     public class Dodongo : IEnemy
     {
-        private CardinalEnemyStateMachine stateMachine;
         public Point Pos { get; set; }
         private readonly Random rnd = new();
-        private SpriteDict dodongoSpriteDict;
-        private CardinalEnemyStateMachine.Direction direction = CardinalEnemyStateMachine.Direction.None;
-        private GraphicsDevice graphicsDevice;
-        private int pixelsMoved;
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
         public bool Alive { get; set; }
+        private EnemyStateMachine.Direction direction = EnemyStateMachine.Direction.None;
+        private GraphicsDevice graphicsDevice;
+        private EnemyStateMachine stateMachine;
+        private CollisionController collisionController;
+        private int pixelsMoved;
 
+        private int health = 6;
         private int tileSize = 64;
 
         public Dodongo(GraphicsDevice graphicsDevice)
@@ -30,20 +31,20 @@ namespace MonoZelda.Enemies.EnemyClasses
             this.graphicsDevice = graphicsDevice;
             Width = 64;
             Height = 64;
+            Alive = true;
         }
 
         public void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController,
             ContentManager contentManager)
         {
+            this.collisionController = collisionController;
             EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), graphicsDevice, EnemyList.Dodongo);
             collisionController.AddCollidable(EnemyHitbox);
-            dodongoSpriteDict = enemyDict;
-            EnemyHitbox.setSpriteDict(dodongoSpriteDict);
-            dodongoSpriteDict.Position = spawnPosition;
-            dodongoSpriteDict.SetSprite("cloud");
+            EnemyHitbox.setSpriteDict(enemyDict);
+            enemyDict.Position = spawnPosition;
             Pos = spawnPosition;
             pixelsMoved = 0;
-            stateMachine = new CardinalEnemyStateMachine(enemyDict);
+            stateMachine = new EnemyStateMachine(enemyDict);
         }
 
         public void ChangeDirection()
@@ -51,23 +52,23 @@ namespace MonoZelda.Enemies.EnemyClasses
             switch (rnd.Next(1, 5))
             {
                 case 1:
-                    direction = CardinalEnemyStateMachine.Direction.Left;
-                    dodongoSpriteDict.SetSprite("dodongo_left");
+                    direction = EnemyStateMachine.Direction.Left;
+                    stateMachine.SetSprite("dodongo_left");
                     Width = 96;
                     break;
                 case 2:
-                    direction = CardinalEnemyStateMachine.Direction.Right;
-                    dodongoSpriteDict.SetSprite("dodongo_right");
+                    direction = EnemyStateMachine.Direction.Right;
+                    stateMachine.SetSprite("dodongo_right");
                     Width = 96;
                     break;
                 case 3:
-                    direction = CardinalEnemyStateMachine.Direction.Up;
-                    dodongoSpriteDict.SetSprite("dodongo_up");
+                    direction = EnemyStateMachine.Direction.Up;
+                    stateMachine.SetSprite("dodongo_up");
                     Width = 64;
                     break;
                 case 4:
-                    direction = CardinalEnemyStateMachine.Direction.Down;
-                    dodongoSpriteDict.SetSprite("dodongo_down");
+                    direction = EnemyStateMachine.Direction.Down;
+                    stateMachine.SetSprite("dodongo_down");
                     Width = 64;
                     break;
             }
@@ -85,14 +86,21 @@ namespace MonoZelda.Enemies.EnemyClasses
             {
                 pixelsMoved++;
                 Pos = stateMachine.Update(this, Pos, gameTime);
-                dodongoSpriteDict.Position = Pos;
             }
         }
 
         public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
-            dodongoSpriteDict.Enabled = false;
-            EnemyHitbox.UnregisterHitbox();
+            if (!stun)
+            {
+                health--;
+                if (health == 0)
+                {
+                    stateMachine.Die();
+                    EnemyHitbox.UnregisterHitbox();
+                    collisionController.RemoveCollidable(EnemyHitbox);
+                }
+            }
         }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Dodongo.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Dodongo.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework.Content;
 using MonoZelda.Collision;
 using MonoZelda.Controllers;
 using Microsoft.Xna.Framework.Graphics;
+using MonoZelda.Link;
 
 namespace MonoZelda.Enemies.EnemyClasses
 {
@@ -88,7 +89,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             }
         }
 
-        public void TakeDamage(Boolean stun)
+        public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
             dodongoSpriteDict.Enabled = false;
             EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyClasses/Gel.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Gel.cs
@@ -17,6 +17,7 @@ namespace MonoZelda.Enemies.EnemyClasses
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
+        public bool Alive { get; set; }
         private readonly Random rnd = new();
         private SpriteDict gelSpriteDict;
         private CardinalEnemyStateMachine.Direction direction = CardinalEnemyStateMachine.Direction.None;
@@ -48,7 +49,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             pixelsMoved = 0;
             spawnTimer = 0;
             readyToJump = false;
-            stateMachine = new CardinalEnemyStateMachine();
+            stateMachine = new CardinalEnemyStateMachine(enemyDict);
         }
 
         public void ChangeDirection()
@@ -105,10 +106,10 @@ namespace MonoZelda.Enemies.EnemyClasses
                 spawnTimer++;
                 gelSpriteDict.Position = Pos;
             }
-            Pos = stateMachine.Update(Pos);
+            Pos = stateMachine.Update(Pos, gameTime);
         }
 
-        public void KillEnemy()
+        public void TakeDamage(Boolean stun)
         {
             gelSpriteDict.Enabled = false;
             EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyClasses/Gel.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Gel.cs
@@ -106,7 +106,7 @@ namespace MonoZelda.Enemies.EnemyClasses
                 spawnTimer++;
                 gelSpriteDict.Position = Pos;
             }
-            Pos = stateMachine.Update(Pos, gameTime);
+            Pos = stateMachine.Update(this, Pos, gameTime);
         }
 
         public void TakeDamage(Boolean stun)

--- a/MonoZelda/Enemies/EnemyClasses/Gel.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Gel.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using MonoZelda.Collision;
 using MonoZelda.Controllers;
+using MonoZelda.Link;
 using MonoZelda.Sprites;
 using Point = Microsoft.Xna.Framework.Point;
 using Rectangle = Microsoft.Xna.Framework.Rectangle;
@@ -109,7 +110,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             Pos = stateMachine.Update(this, Pos, gameTime);
         }
 
-        public void TakeDamage(Boolean stun)
+        public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
             gelSpriteDict.Enabled = false;
             EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyClasses/Goriya.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Goriya.cs
@@ -17,6 +17,7 @@ namespace MonoZelda.Enemies.EnemyClasses
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
+        public bool Alive { get; set; }
         private CardinalEnemyStateMachine stateMachine;
         private readonly Random rnd = new();
         private SpriteDict goriyaSpriteDict;
@@ -52,7 +53,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             Pos = spawnPosition;
             pixelsMoved = 0;
             tilesMoved = 0;
-            stateMachine = new CardinalEnemyStateMachine();
+            stateMachine = new CardinalEnemyStateMachine(enemyDict);
             projectile = new GoriyaBoomerang(spawnPosition, contentManager, graphicsDevice, collisionController);
             projectileCollision = new EnemyProjectileCollisionManager(projectile, collisionController);
         }
@@ -105,7 +106,7 @@ namespace MonoZelda.Enemies.EnemyClasses
                 }
                 else
                 {
-                    KillEnemy();
+                    TakeDamage(true);
                 }
             }
             else if (tilesMoved < 3)
@@ -119,7 +120,7 @@ namespace MonoZelda.Enemies.EnemyClasses
 
                 pixelsMoved++;
                 projectile.Follow(Pos);
-                Pos = stateMachine.Update(Pos);
+                Pos = stateMachine.Update(Pos, gameTime);
                 goriyaSpriteDict.Position = Pos;
             }
             else
@@ -129,7 +130,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             projectileCollision.Update();
 
         }
-        public void KillEnemy()
+        public void TakeDamage(Boolean stun)
         {
             if (goriyaAlive == true && animatedDeath < 12)
             {

--- a/MonoZelda/Enemies/EnemyClasses/Goriya.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Goriya.cs
@@ -20,10 +20,10 @@ namespace MonoZelda.Enemies.EnemyClasses
         public int Width { get; set; }
         public int Height { get; set; }
         public bool Alive { get; set; }
-        private CardinalEnemyStateMachine stateMachine;
+        private EnemyStateMachine stateMachine;
         private readonly Random rnd = new();
-        private CardinalEnemyStateMachine.Direction direction = CardinalEnemyStateMachine.Direction.None;
-        private CardinalEnemyStateMachine.Direction projDirection;
+        private EnemyStateMachine.Direction direction = EnemyStateMachine.Direction.None;
+        private EnemyStateMachine.Direction projDirection;
         private readonly GraphicsDevice graphicsDevice;
         private IEnemyProjectile projectile;
         private EnemyProjectileCollisionManager projectileCollision;
@@ -45,13 +45,13 @@ namespace MonoZelda.Enemies.EnemyClasses
         public void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ContentManager contentManager)
         {
             this.collisionController = collisionController;
-            EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, 48, 48), graphicsDevice, EnemyList.Goriya);
+            EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), graphicsDevice, EnemyList.Goriya);
             collisionController.AddCollidable(EnemyHitbox);
             EnemyHitbox.setSpriteDict(enemyDict);
             enemyDict.Position = spawnPosition;
             Pos = spawnPosition;
             pixelsMoved = 0;
-            stateMachine = new CardinalEnemyStateMachine(enemyDict);
+            stateMachine = new EnemyStateMachine(enemyDict);
             projectile = new GoriyaBoomerang(spawnPosition, contentManager, graphicsDevice, collisionController);
             projectileCollision = new EnemyProjectileCollisionManager(projectile, collisionController);
         }
@@ -61,19 +61,19 @@ namespace MonoZelda.Enemies.EnemyClasses
             switch (rnd.Next(1, 5))
             {
                 case 1:
-                    direction = CardinalEnemyStateMachine.Direction.Left;
+                    direction = EnemyStateMachine.Direction.Left;
                     stateMachine.SetSprite("goriya_red_left");
                     break;
                 case 2:
-                    direction = CardinalEnemyStateMachine.Direction.Right;
+                    direction = EnemyStateMachine.Direction.Right;
                     stateMachine.SetSprite("goriya_red_right");
                     break;
                 case 3:
-                    direction = CardinalEnemyStateMachine.Direction.Up;
+                    direction = EnemyStateMachine.Direction.Up;
                     stateMachine.SetSprite("goriya_red_up");
                     break;
                 case 4:
-                    direction = CardinalEnemyStateMachine.Direction.Down;
+                    direction = EnemyStateMachine.Direction.Down;
                     stateMachine.SetSprite("goriya_red_down");
                     break;
             }
@@ -87,7 +87,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             if (Math.Abs(projectile.Pos.X - Pos.X) < 3 && Math.Abs(projectile.Pos.Y - Pos.Y) < 3)
             {
                 projectile.ViewProjectile(false, Alive);
-                projDirection = CardinalEnemyStateMachine.Direction.None;
+                projDirection = EnemyStateMachine.Direction.None;
                 pixelsMoved = 0;
                 ChangeDirection();
             }
@@ -98,7 +98,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             if (pixelsMoved > tileSize*3 - 1)
             {
                 projDirection = direction;
-                stateMachine.ChangeDirection(CardinalEnemyStateMachine.Direction.None);
+                stateMachine.ChangeDirection(EnemyStateMachine.Direction.None);
                 Attack(gameTime);
             }
             else if (pixelsMoved >= 0)
@@ -121,13 +121,17 @@ namespace MonoZelda.Enemies.EnemyClasses
         {
             if (stun)
             {
-                stateMachine.ChangeDirection(CardinalEnemyStateMachine.Direction.None);
+                stateMachine.ChangeDirection(EnemyStateMachine.Direction.None);
                 pixelsMoved = -128;
             }
             else
             {
                 health--;
-                if (health == 0)
+                if (health > 0)
+                {
+                    stateMachine.Knockback(true, collisionDirection);
+                }
+                else
                 {
                     projectileActive = false;
                     stateMachine.Die();

--- a/MonoZelda/Enemies/EnemyClasses/Keese.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Keese.cs
@@ -11,103 +11,104 @@ namespace MonoZelda.Enemies.EnemyClasses
 {
     public class Keese : IEnemy
     {
-        private  DiagonalEnemyStateMachine stateMachine;
+        private EnemyStateMachine stateMachine;
         private readonly Random rnd = new();
         public Point Pos { get; set; }
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
         public bool Alive { get; set; }
-        private SpriteDict keeseSpriteDict;
-        private DiagonalEnemyStateMachine.VertDirection vertDirection = DiagonalEnemyStateMachine.VertDirection.None;
-        private DiagonalEnemyStateMachine.HorDirection horDirection = DiagonalEnemyStateMachine.HorDirection.None;
+        private EnemyStateMachine.Direction direction = EnemyStateMachine.Direction.None;
         private readonly GraphicsDevice graphicsDevice;
+        private CollisionController collisionController;
         private int pixelsMoved;
+        private double speedUpTimer;
+        private double dt;
+        private float speed;
 
         public Keese(GraphicsDevice graphicsDevice)
         {
             this.graphicsDevice = graphicsDevice;
-            Height = 64;
-            Width = 64;
+            Width = 48;
+            Height = 48;
+            Alive = true;
         }
 
         public void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController,
             ContentManager contentManager)
         {
-            EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, 60, 60), graphicsDevice, EnemyList.Keese);
+            this.collisionController = collisionController;
+            EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), graphicsDevice, EnemyList.Keese);
             collisionController.AddCollidable(EnemyHitbox);
             EnemyHitbox.setSpriteDict(enemyDict);
             enemyDict.Position = spawnPosition;
             enemyDict.SetSprite("cloud");
-            keeseSpriteDict = enemyDict;
             Pos = spawnPosition;
             pixelsMoved = 0;
-            stateMachine = new DiagonalEnemyStateMachine();
+            speed = 0;
+            speedUpTimer = 0;
+            stateMachine = new EnemyStateMachine(enemyDict);
+            stateMachine.SetSprite("keese_blue");
         }
 
         public void ChangeDirection()
         {
-            keeseSpriteDict.SetSprite("keese_blue");
-            stateMachine.ChangeHorDirection(horDirection);
-            stateMachine.ChangeVertDirection(vertDirection);
-        }
-
-        public void UpdateHorDirection()
-        {
-            switch (rnd.Next(1, 4))
+            switch (rnd.Next(1, 9))
             {
                 case 1:
-                    horDirection = DiagonalEnemyStateMachine.HorDirection.Left;
+                    direction = EnemyStateMachine.Direction.Left;
                     break;
                 case 2:
-                    horDirection = DiagonalEnemyStateMachine.HorDirection.Right;
+                    direction = EnemyStateMachine.Direction.Right;
                     break;
                 case 3:
-                    horDirection = DiagonalEnemyStateMachine.HorDirection.None;
-                    UpdateVertDirection();
+                    direction = EnemyStateMachine.Direction.Up;
+                    break;
+                case 4:
+                    direction = EnemyStateMachine.Direction.Down;
+                    break;
+                case 5:
+                    direction = EnemyStateMachine.Direction.UpLeft;
+                    break;
+                case 6:
+                    direction = EnemyStateMachine.Direction.UpRight;
+                    break;
+                case 7:
+                    direction = EnemyStateMachine.Direction.DownLeft;
+                    break;
+                case 8:
+                    direction = EnemyStateMachine.Direction.DownRight;
                     break;
             }
-        }
-
-        public void UpdateVertDirection()
-        {
-            switch (rnd.Next(1, 4))
-            {
-                case 1:
-                    vertDirection = DiagonalEnemyStateMachine.VertDirection.Up;
-                    break;
-                case 2:
-                    vertDirection = DiagonalEnemyStateMachine.VertDirection.Down;
-                    break;
-                case 3:
-                    vertDirection = DiagonalEnemyStateMachine.VertDirection.None;
-                    UpdateHorDirection();
-                    break;
-            }
+            stateMachine.ChangeDirection(direction);
         }
 
         public void Update(GameTime gameTime)
         {
+            dt = gameTime.ElapsedGameTime.TotalSeconds;
+            if (speedUpTimer < 2)
+            {
+                speedUpTimer += dt;
+                speed++;
+                stateMachine.ChangeSpeed(speed);
+            }
             if (pixelsMoved >= 64)
             {
                 pixelsMoved = 0;
-
-                UpdateHorDirection();
-                UpdateVertDirection();
                 ChangeDirection();
             }
             else
             {
                 pixelsMoved++;
-                keeseSpriteDict.Position = Pos;
             }
-            Pos = stateMachine.Update(Pos);
+            Pos = stateMachine.Update(this, Pos, gameTime);
         }
 
         public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
-            keeseSpriteDict.Enabled = false;
+            stateMachine.Die();
             EnemyHitbox.UnregisterHitbox();
+            collisionController.RemoveCollidable(EnemyHitbox);
         }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Keese.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Keese.cs
@@ -16,6 +16,7 @@ namespace MonoZelda.Enemies.EnemyClasses
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
+        public bool Alive { get; set; }
         private SpriteDict keeseSpriteDict;
         private DiagonalEnemyStateMachine.VertDirection vertDirection = DiagonalEnemyStateMachine.VertDirection.None;
         private DiagonalEnemyStateMachine.HorDirection horDirection = DiagonalEnemyStateMachine.HorDirection.None;
@@ -102,7 +103,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             Pos = stateMachine.Update(Pos);
         }
 
-        public void KillEnemy()
+        public void TakeDamage(Boolean stun)
         {
             keeseSpriteDict.Enabled = false;
             EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyClasses/Keese.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Keese.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using MonoZelda.Collision;
 using MonoZelda.Controllers;
+using MonoZelda.Link;
 using MonoZelda.Sprites;
 
 namespace MonoZelda.Enemies.EnemyClasses
@@ -103,7 +104,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             Pos = stateMachine.Update(Pos);
         }
 
-        public void TakeDamage(Boolean stun)
+        public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
             keeseSpriteDict.Enabled = false;
             EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyClasses/Oldman.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Oldman.cs
@@ -16,6 +16,7 @@ namespace MonoZelda.Enemies.EnemyClasses
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
+        public bool Alive { get; set; }
 
         private int spawnTimer;
 
@@ -56,7 +57,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             }
         }
 
-        public void KillEnemy()
+        public void TakeDamage(Boolean stun)
         {
             // oldman is immortal
         }

--- a/MonoZelda/Enemies/EnemyClasses/Oldman.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Oldman.cs
@@ -5,6 +5,7 @@ using MonoZelda.Collision;
 using MonoZelda.Controllers;
 using MonoZelda.Sprites;
 using System;
+using MonoZelda.Link;
 
 namespace MonoZelda.Enemies.EnemyClasses
 {
@@ -57,7 +58,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             }
         }
 
-        public void TakeDamage(Boolean stun)
+        public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
             // oldman is immortal
         }

--- a/MonoZelda/Enemies/EnemyClasses/Oldman.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Oldman.cs
@@ -26,13 +26,14 @@ namespace MonoZelda.Enemies.EnemyClasses
             this.graphicsDevice = graphicsDevice;
             Width = 64;
             Height = 64;
+            Alive = true;
 
         }
 
         public void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController,
             ContentManager contentManager)
         {
-            EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, 60, 60), graphicsDevice, EnemyList.Oldman);
+            EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), graphicsDevice, EnemyList.Oldman);
             collisionController.AddCollidable(EnemyHitbox);
             EnemyHitbox.setSpriteDict(enemyDict);
             enemyDict.Position = spawnPosition;

--- a/MonoZelda/Enemies/EnemyClasses/Rope.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Rope.cs
@@ -20,6 +20,7 @@ namespace MonoZelda.Enemies.EnemyClasses
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
+        public bool Alive { get; set; }
 
         private int tileSize = 64;
 
@@ -41,7 +42,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             ropeSpriteDict.SetSprite("cloud");
             Pos = spawnPosition;
             pixelsMoved = 0;
-            stateMachine = new CardinalEnemyStateMachine();
+            stateMachine = new CardinalEnemyStateMachine(enemyDict);
         }
 
         public void ChangeDirection()
@@ -79,10 +80,10 @@ namespace MonoZelda.Enemies.EnemyClasses
                 pixelsMoved++;
                 ropeSpriteDict.Position = Pos;
             }
-            Pos = stateMachine.Update(Pos);
+            Pos = stateMachine.Update(Pos, gameTime);
         }
 
-        public void KillEnemy()
+        public void TakeDamage(Boolean stun)
         {
             ropeSpriteDict.Enabled = false;
             EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyClasses/Rope.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Rope.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using MonoZelda.Collision;
 using MonoZelda.Controllers;
+using MonoZelda.Link;
 using MonoZelda.Sprites;
 
 namespace MonoZelda.Enemies.EnemyClasses
@@ -83,7 +84,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             Pos = stateMachine.Update(this, Pos, gameTime);
         }
 
-        public void TakeDamage(Boolean stun)
+        public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
             ropeSpriteDict.Enabled = false;
             EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyClasses/Rope.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Rope.cs
@@ -80,7 +80,7 @@ namespace MonoZelda.Enemies.EnemyClasses
                 pixelsMoved++;
                 ropeSpriteDict.Position = Pos;
             }
-            Pos = stateMachine.Update(Pos, gameTime);
+            Pos = stateMachine.Update(this, Pos, gameTime);
         }
 
         public void TakeDamage(Boolean stun)

--- a/MonoZelda/Enemies/EnemyClasses/Rope.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Rope.cs
@@ -11,59 +11,60 @@ namespace MonoZelda.Enemies.EnemyClasses
 {
     public class Rope : IEnemy
     {
-        private CardinalEnemyStateMachine stateMachine;
         public Point Pos { get; set; }
-        private readonly Random rnd = new();
-        private SpriteDict ropeSpriteDict;
-        private CardinalEnemyStateMachine.Direction direction = CardinalEnemyStateMachine.Direction.None;
-        private GraphicsDevice graphicsDevice;
-        private int pixelsMoved;
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
         public bool Alive { get; set; }
+        private readonly Random rnd = new();
+        private EnemyStateMachine.Direction direction = EnemyStateMachine.Direction.None;
+        private GraphicsDevice graphicsDevice;
+        private EnemyStateMachine stateMachine;
+        private CollisionController collisionController;
 
+        private int pixelsMoved;
+        private int health = 3;
         private int tileSize = 64;
 
         public Rope(GraphicsDevice graphicsDevice)
         {
             this.graphicsDevice = graphicsDevice;
-            Width = 64;
-            Height = 64;
+            Width = 48;
+            Height = 48;
+            Alive = true;
         }
 
         public void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController,
             ContentManager contentManager)
         {
+            this.collisionController = collisionController;
             EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), graphicsDevice, EnemyList.Rope);
             collisionController.AddCollidable(EnemyHitbox);
-            ropeSpriteDict = enemyDict;
-            EnemyHitbox.setSpriteDict(ropeSpriteDict);
-            ropeSpriteDict.Position = spawnPosition;
-            ropeSpriteDict.SetSprite("cloud");
+            EnemyHitbox.setSpriteDict(enemyDict);
+            enemyDict.Position = spawnPosition;
             Pos = spawnPosition;
             pixelsMoved = 0;
-            stateMachine = new CardinalEnemyStateMachine(enemyDict);
+            stateMachine = new EnemyStateMachine(enemyDict);
         }
 
         public void ChangeDirection()
         {
-            ropeSpriteDict.SetSprite("rope_left");
+            stateMachine.SetSprite("rope_left");
             switch (rnd.Next(1, 5))
             {
                 case 1:
-                    direction = CardinalEnemyStateMachine.Direction.Left;
-                    ropeSpriteDict.SetSprite("rope_left");
+                    direction = EnemyStateMachine.Direction.Left;
+                    stateMachine.SetSprite("rope_left");
                     break;
                 case 2:
-                    direction = CardinalEnemyStateMachine.Direction.Right;
-                    ropeSpriteDict.SetSprite("rope_right");
+                    direction = EnemyStateMachine.Direction.Right;
+                    stateMachine.SetSprite("rope_right");
                     break;
                 case 3:
-                    direction = CardinalEnemyStateMachine.Direction.Up;
+                    direction = EnemyStateMachine.Direction.Up;
                     break;
                 case 4:
-                    direction = CardinalEnemyStateMachine.Direction.Down;
+                    direction = EnemyStateMachine.Direction.Down;
                     break;
             }
             stateMachine.ChangeDirection(direction);
@@ -79,15 +80,31 @@ namespace MonoZelda.Enemies.EnemyClasses
             else
             {
                 pixelsMoved++;
-                ropeSpriteDict.Position = Pos;
             }
             Pos = stateMachine.Update(this, Pos, gameTime);
         }
 
         public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
-            ropeSpriteDict.Enabled = false;
-            EnemyHitbox.UnregisterHitbox();
+            if (stun)
+            {
+                stateMachine.ChangeDirection(EnemyStateMachine.Direction.None);
+                pixelsMoved = -128;
+            }
+            else
+            {
+                health--;
+                if (health > 0)
+                {
+                    stateMachine.Knockback(true, collisionDirection);
+                }
+                else
+                {
+                    stateMachine.Die();
+                    EnemyHitbox.UnregisterHitbox();
+                    collisionController.RemoveCollidable(EnemyHitbox);
+                }
+            }
         }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Stalfos.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Stalfos.cs
@@ -17,8 +17,8 @@ namespace MonoZelda.Enemies.EnemyClasses
         public int Width { get; set; }
         public int Height { get; set; }
         public Boolean Alive { get; set; }
-        private CardinalEnemyStateMachine stateMachine;
-        private CardinalEnemyStateMachine.Direction direction = CardinalEnemyStateMachine.Direction.None;
+        private EnemyStateMachine stateMachine;
+        private EnemyStateMachine.Direction direction = EnemyStateMachine.Direction.None;
         private readonly GraphicsDevice graphicsDevice;
         private CollisionController collisionController;
         private int pixelsMoved;
@@ -37,13 +37,13 @@ namespace MonoZelda.Enemies.EnemyClasses
         public void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ContentManager contentManager)
         {
             this.collisionController = collisionController;
-            EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, 48, 48), graphicsDevice, EnemyList.Stalfos);
+            EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), graphicsDevice, EnemyList.Stalfos);
             collisionController.AddCollidable(EnemyHitbox);
             EnemyHitbox.setSpriteDict(enemyDict);
             enemyDict.Position = spawnPosition;
             Pos = spawnPosition;
             pixelsMoved = 0;
-            stateMachine = new CardinalEnemyStateMachine(enemyDict);
+            stateMachine = new EnemyStateMachine(enemyDict);
             stateMachine.SetSprite("stalfos");
         }
 
@@ -52,16 +52,16 @@ namespace MonoZelda.Enemies.EnemyClasses
             switch (rnd.Next(1, 5))
             {
                 case 1:
-                    direction = CardinalEnemyStateMachine.Direction.Left;
+                    direction = EnemyStateMachine.Direction.Left;
                     break;
                 case 2:
-                    direction = CardinalEnemyStateMachine.Direction.Right;
+                    direction = EnemyStateMachine.Direction.Right;
                     break;
                 case 3:
-                    direction = CardinalEnemyStateMachine.Direction.Up;
+                    direction = EnemyStateMachine.Direction.Up;
                     break;
                 case 4:
-                    direction = CardinalEnemyStateMachine.Direction.Down;
+                    direction = EnemyStateMachine.Direction.Down;
                     break;
             }
             stateMachine.ChangeDirection(direction);
@@ -85,12 +85,12 @@ namespace MonoZelda.Enemies.EnemyClasses
         {
             if (stun)
             {
-                stateMachine.ChangeDirection(CardinalEnemyStateMachine.Direction.None);
+                stateMachine.ChangeDirection(EnemyStateMachine.Direction.None);
                 pixelsMoved = -128;
             }
             else
             {
-                //health--;
+                health--;
                 if (health > 0)
                 {
                     stateMachine.Knockback(true, collisionDirection);

--- a/MonoZelda/Enemies/EnemyClasses/Stalfos.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Stalfos.cs
@@ -5,33 +5,33 @@ using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using MonoZelda.Collision;
 using MonoZelda.Controllers;
+using MonoZelda.Link;
 using MonoZelda.Sprites;
 
 namespace MonoZelda.Enemies.EnemyClasses
 {
     public class Stalfos : IEnemy
     {
-        private CardinalEnemyStateMachine stateMachine;
         public Point Pos { get; set; }
-        private readonly Random rnd = new();
-        private CardinalEnemyStateMachine.Direction direction = CardinalEnemyStateMachine.Direction.None;
-        private GraphicsDevice graphicsDevice;
-        private CollisionController collisionController;
-        private int pixelsMoved;
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
         public Boolean Alive { get; set; }
+        private CardinalEnemyStateMachine stateMachine;
+        private CardinalEnemyStateMachine.Direction direction = CardinalEnemyStateMachine.Direction.None;
+        private readonly GraphicsDevice graphicsDevice;
+        private CollisionController collisionController;
+        private int pixelsMoved;
         private int health = 2;
-        private int tileSize = 64;
-        private double damageDelay;
-        private double dt;
+        private readonly int tileSize = 64;
+        private readonly Random rnd = new();
 
         public Stalfos(GraphicsDevice graphicsDevice)
         {
             this.graphicsDevice = graphicsDevice;
             Width = 48;
             Height = 48;
+            Alive = true;
         }
 
         public void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ContentManager contentManager)
@@ -69,7 +69,6 @@ namespace MonoZelda.Enemies.EnemyClasses
 
         public void Update(GameTime gameTime)
         {
-            dt = gameTime.ElapsedGameTime.TotalSeconds;
             if (pixelsMoved >= tileSize)
             {
                 pixelsMoved = 0;
@@ -80,10 +79,9 @@ namespace MonoZelda.Enemies.EnemyClasses
                 pixelsMoved++;
             }
             Pos = stateMachine.Update(this,Pos,gameTime);
-            damageDelay -= dt;
         }
 
-        public void TakeDamage(Boolean stun)
+        public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
             if (stun)
             {
@@ -92,9 +90,12 @@ namespace MonoZelda.Enemies.EnemyClasses
             }
             else
             {
-                health--;
-                damageDelay = 0.5;
-                if (health == 0)
+                //health--;
+                if (health > 0)
+                {
+                    stateMachine.Knockback(true, collisionDirection);
+                }
+                else
                 {
                     stateMachine.Die();
                     EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyClasses/Stalfos.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Stalfos.cs
@@ -79,7 +79,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             {
                 pixelsMoved++;
             }
-            Pos = stateMachine.Update(Pos,gameTime);
+            Pos = stateMachine.Update(this,Pos,gameTime);
             damageDelay -= dt;
         }
 
@@ -96,7 +96,6 @@ namespace MonoZelda.Enemies.EnemyClasses
                 damageDelay = 0.5;
                 if (health == 0)
                 {
-                    Alive = false;
                     stateMachine.Die();
                     EnemyHitbox.UnregisterHitbox();
                     collisionController.RemoveCollidable(EnemyHitbox);

--- a/MonoZelda/Enemies/EnemyClasses/Trap.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Trap.cs
@@ -5,6 +5,7 @@ using MonoZelda.Collision;
 using MonoZelda.Controllers;
 using MonoZelda.Sprites;
 using System;
+using MonoZelda.Link;
 
 namespace MonoZelda.Enemies.EnemyClasses
 {
@@ -84,7 +85,7 @@ namespace MonoZelda.Enemies.EnemyClasses
         {
         }
 
-        public void TakeDamage(Boolean stun)
+        public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
             trapSpriteDict.Enabled = false;
             EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyClasses/Trap.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Trap.cs
@@ -22,6 +22,7 @@ namespace MonoZelda.Enemies.EnemyClasses
         private EnemyCollidable verticalHitbox;
         public int Width { get; set; }
         public int Height { get; set; }
+        public bool Alive { get; set; }
 
         private int tileSize = 64;
 
@@ -73,7 +74,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             trapSpriteDict.SetSprite("bladetrap");
             Pos = spawnPosition;
             pixelsMoved = 0;
-            stateMachine = new CardinalEnemyStateMachine();
+            stateMachine = new CardinalEnemyStateMachine(enemyDict);
         }
         public void ChangeDirection()
         {
@@ -83,7 +84,7 @@ namespace MonoZelda.Enemies.EnemyClasses
         {
         }
 
-        public void KillEnemy()
+        public void TakeDamage(Boolean stun)
         {
             trapSpriteDict.Enabled = false;
             EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyClasses/Trap.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Trap.cs
@@ -11,11 +11,11 @@ namespace MonoZelda.Enemies.EnemyClasses
 {
     public class Trap : IEnemy
     {
-        private CardinalEnemyStateMachine stateMachine;
+        private EnemyStateMachine stateMachine;
         public Point Pos { get; set; }
         private readonly Random rnd = new();
         private SpriteDict trapSpriteDict;
-        private CardinalEnemyStateMachine.Direction direction = CardinalEnemyStateMachine.Direction.None;
+        private EnemyStateMachine.Direction direction = EnemyStateMachine.Direction.None;
         private GraphicsDevice graphicsDevice;
         private int pixelsMoved;
         public EnemyCollidable EnemyHitbox { get; set; }
@@ -75,7 +75,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             trapSpriteDict.SetSprite("bladetrap");
             Pos = spawnPosition;
             pixelsMoved = 0;
-            stateMachine = new CardinalEnemyStateMachine(enemyDict);
+            stateMachine = new EnemyStateMachine(enemyDict);
         }
         public void ChangeDirection()
         {

--- a/MonoZelda/Enemies/EnemyClasses/Wallmaster.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Wallmaster.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework.Content;
 using MonoZelda.Collision;
 using MonoZelda.Controllers;
 using Microsoft.Xna.Framework.Graphics;
+using MonoZelda.Link;
 
 namespace MonoZelda.Enemies.EnemyClasses
 {
@@ -81,7 +82,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             Pos = stateMachine.Update(this, Pos, gameTime);
         }
 
-        public void TakeDamage(Boolean stun)
+        public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
             wallmasterSpriteDict.Enabled = false;
             EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyClasses/Wallmaster.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Wallmaster.cs
@@ -20,6 +20,7 @@ namespace MonoZelda.Enemies.EnemyClasses
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
+        public bool Alive { get; set; }
 
         private int tileSize = 64;
 
@@ -41,7 +42,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             wallmasterSpriteDict.SetSprite("cloud");
             Pos = spawnPosition;
             pixelsMoved = 0;
-            stateMachine = new CardinalEnemyStateMachine();
+            stateMachine = new CardinalEnemyStateMachine(enemyDict);
         }
         public void ChangeDirection()
         {
@@ -77,10 +78,10 @@ namespace MonoZelda.Enemies.EnemyClasses
                 pixelsMoved++;
                 wallmasterSpriteDict.Position = Pos;
             }
-            Pos = stateMachine.Update(Pos);
+            Pos = stateMachine.Update(Pos, gameTime);
         }
 
-        public void KillEnemy()
+        public void TakeDamage(Boolean stun)
         {
             wallmasterSpriteDict.Enabled = false;
             EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyClasses/Wallmaster.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Wallmaster.cs
@@ -11,58 +11,59 @@ namespace MonoZelda.Enemies.EnemyClasses
 {
     public class Wallmaster : IEnemy
     {
-        private CardinalEnemyStateMachine stateMachine;
         public Point Pos { get; set; }
-        private readonly Random rnd = new();
-        private SpriteDict wallmasterSpriteDict;
-        private CardinalEnemyStateMachine.Direction direction = CardinalEnemyStateMachine.Direction.None;
-        private GraphicsDevice graphicsDevice;
-        private int pixelsMoved;
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
         public bool Alive { get; set; }
+        private readonly Random rnd = new();
+        private EnemyStateMachine.Direction direction = EnemyStateMachine.Direction.None;
+        private GraphicsDevice graphicsDevice;
+        private EnemyStateMachine stateMachine;
+        private CollisionController collisionController;
 
+        private int pixelsMoved;
+        private int health = 3;
         private int tileSize = 64;
 
         public Wallmaster(GraphicsDevice graphicsDevice)
         {
             this.graphicsDevice = graphicsDevice;
-            Width = 64;
-            Height = 64;
+            Width = 48;
+            Height = 48;
+            Alive = true;
         }
 
         public void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController,
             ContentManager contentManager)
         {
+            this.collisionController = collisionController;
             EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), graphicsDevice, EnemyList.Wallmaster);
             collisionController.AddCollidable(EnemyHitbox);
-            wallmasterSpriteDict = enemyDict;
-            EnemyHitbox.setSpriteDict(wallmasterSpriteDict);
-            wallmasterSpriteDict.Position = spawnPosition;
-            wallmasterSpriteDict.SetSprite("cloud");
+            EnemyHitbox.setSpriteDict(enemyDict);
+            enemyDict.Position = spawnPosition;
             Pos = spawnPosition;
             pixelsMoved = 0;
-            stateMachine = new CardinalEnemyStateMachine(enemyDict);
+            stateMachine = new EnemyStateMachine(enemyDict);
+            stateMachine.SetSprite("wallmaster");
         }
         public void ChangeDirection()
         {
             switch (rnd.Next(1, 5))
             {
                 case 1:
-                    direction = CardinalEnemyStateMachine.Direction.Left;
+                    direction = EnemyStateMachine.Direction.Left;
                     break;
                 case 2:
-                    direction = CardinalEnemyStateMachine.Direction.Right;
+                    direction = EnemyStateMachine.Direction.Right;
                     break;
                 case 3:
-                    direction = CardinalEnemyStateMachine.Direction.Up;
+                    direction = EnemyStateMachine.Direction.Up;
                     break;
                 case 4:
-                    direction = CardinalEnemyStateMachine.Direction.Down;
+                    direction = EnemyStateMachine.Direction.Down;
                     break;
             }
-            wallmasterSpriteDict.SetSprite("wallmaster");
             stateMachine.ChangeDirection(direction);
         }
 
@@ -77,15 +78,31 @@ namespace MonoZelda.Enemies.EnemyClasses
             else
             {
                 pixelsMoved++;
-                wallmasterSpriteDict.Position = Pos;
             }
             Pos = stateMachine.Update(this, Pos, gameTime);
         }
 
         public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
-            wallmasterSpriteDict.Enabled = false;
-            EnemyHitbox.UnregisterHitbox();
+            if (stun)
+            {
+                stateMachine.ChangeDirection(EnemyStateMachine.Direction.None);
+                pixelsMoved = -128;
+            }
+            else
+            {
+                health--;
+                if (health > 0)
+                {
+                    stateMachine.Knockback(true, collisionDirection);
+                }
+                else
+                {
+                    stateMachine.Die();
+                    EnemyHitbox.UnregisterHitbox();
+                    collisionController.RemoveCollidable(EnemyHitbox);
+                }
+            }
         }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Wallmaster.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Wallmaster.cs
@@ -78,7 +78,7 @@ namespace MonoZelda.Enemies.EnemyClasses
                 pixelsMoved++;
                 wallmasterSpriteDict.Position = Pos;
             }
-            Pos = stateMachine.Update(Pos, gameTime);
+            Pos = stateMachine.Update(this, Pos, gameTime);
         }
 
         public void TakeDamage(Boolean stun)

--- a/MonoZelda/Enemies/EnemyClasses/Zol.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Zol.cs
@@ -89,7 +89,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             else
             {
                 pixelsMoved++;
-                Pos = stateMachine.Update(Pos, gameTime);
+                Pos = stateMachine.Update(this, Pos, gameTime);
                 zolSpriteDict.Position = Pos;
             }
         }

--- a/MonoZelda/Enemies/EnemyClasses/Zol.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Zol.cs
@@ -11,17 +11,18 @@ namespace MonoZelda.Enemies.EnemyClasses
 {
     public class Zol : IEnemy
     {
-        private CardinalEnemyStateMachine stateMachine;
+        private EnemyStateMachine stateMachine;
         public Point Pos { get; set; }
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
         public bool Alive { get; set; }
         private readonly Random rnd = new();
-        private SpriteDict zolSpriteDict;
-        private CardinalEnemyStateMachine.Direction direction = CardinalEnemyStateMachine.Direction.None;
+        private EnemyStateMachine.Direction direction = EnemyStateMachine.Direction.None;
         private readonly GraphicsDevice graphicsDevice;
+        private CollisionController collisionController;
 
+        private int health = 2;
         private int tileSize = 64;
         private int pixelsMoved;
         private bool readyToJump;
@@ -29,28 +30,43 @@ namespace MonoZelda.Enemies.EnemyClasses
         public Zol(GraphicsDevice graphicsDevice)
         {
             this.graphicsDevice = graphicsDevice;
-            Width = 64;
-            Height = 64;
+            Width = 48;
+            Height = 48;
+            Alive = true;
         }
 
         public void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController,
             ContentManager contentManager)
         {
+            this.collisionController = collisionController;
             EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), graphicsDevice, EnemyList.Zol);
             collisionController.AddCollidable(EnemyHitbox);
-            zolSpriteDict = enemyDict;
-            EnemyHitbox.setSpriteDict(zolSpriteDict);
-            zolSpriteDict.Position = spawnPosition;
-            zolSpriteDict.SetSprite("cloud");
+            EnemyHitbox.setSpriteDict(enemyDict);
+            enemyDict.Position = spawnPosition;
             Pos = spawnPosition;
             pixelsMoved = 0;
             readyToJump = false;
-            stateMachine = new CardinalEnemyStateMachine(enemyDict);
+            stateMachine = new EnemyStateMachine(enemyDict);
+            stateMachine.SetSprite("zol_brown");
         }
         public void ChangeDirection()
         {
+            switch (rnd.Next(1, 5))
+            {
+                case 1:
+                    direction = EnemyStateMachine.Direction.Left;
+                    break;
+                case 2:
+                    direction = EnemyStateMachine.Direction.Right;
+                    break;
+                case 3:
+                    direction = EnemyStateMachine.Direction.Up;
+                    break;
+                case 4:
+                    direction = EnemyStateMachine.Direction.Down;
+                    break;
+            }
             stateMachine.ChangeDirection(direction);
-            zolSpriteDict.SetSprite("zol_brown");
         }
 
 
@@ -58,27 +74,12 @@ namespace MonoZelda.Enemies.EnemyClasses
         {
             if (readyToJump)
             {
-                switch (rnd.Next(1, 5))
-                {
-                    case 1:
-                        direction = CardinalEnemyStateMachine.Direction.Left;
-                        break;
-                    case 2:
-                        direction = CardinalEnemyStateMachine.Direction.Right;
-                        break;
-                    case 3:
-                        direction = CardinalEnemyStateMachine.Direction.Up;
-                        break;
-                    case 4:
-                        direction = CardinalEnemyStateMachine.Direction.Down;
-                        break;
-                }
                 readyToJump = false;
                 ChangeDirection();
             }
             else if (pixelsMoved >= tileSize)
             {
-                direction = CardinalEnemyStateMachine.Direction.None;
+                direction = EnemyStateMachine.Direction.None;
                 ChangeDirection();
                 pixelsMoved++;
                 if (pixelsMoved >= tileSize + 30)
@@ -91,14 +92,30 @@ namespace MonoZelda.Enemies.EnemyClasses
             {
                 pixelsMoved++;
                 Pos = stateMachine.Update(this, Pos, gameTime);
-                zolSpriteDict.Position = Pos;
             }
         }
 
         public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
-            zolSpriteDict.Enabled = false;
-            EnemyHitbox.UnregisterHitbox();
+            if (stun)
+            {
+                stateMachine.ChangeDirection(EnemyStateMachine.Direction.None);
+                pixelsMoved = -128;
+            }
+            else
+            {
+                health--;
+                if (health > 0)
+                {
+                    stateMachine.Knockback(true, collisionDirection);
+                }
+                else
+                {
+                    stateMachine.Die();
+                    EnemyHitbox.UnregisterHitbox();
+                    collisionController.RemoveCollidable(EnemyHitbox);
+                }
+            }
         }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Zol.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Zol.cs
@@ -15,6 +15,7 @@ namespace MonoZelda.Enemies.EnemyClasses
         public EnemyCollidable EnemyHitbox { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
+        public bool Alive { get; set; }
         private readonly Random rnd = new();
         private SpriteDict zolSpriteDict;
         private CardinalEnemyStateMachine.Direction direction = CardinalEnemyStateMachine.Direction.None;
@@ -43,7 +44,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             Pos = spawnPosition;
             pixelsMoved = 0;
             readyToJump = false;
-            stateMachine = new CardinalEnemyStateMachine();
+            stateMachine = new CardinalEnemyStateMachine(enemyDict);
         }
         public void ChangeDirection()
         {
@@ -88,12 +89,12 @@ namespace MonoZelda.Enemies.EnemyClasses
             else
             {
                 pixelsMoved++;
-                Pos = stateMachine.Update(Pos);
+                Pos = stateMachine.Update(Pos, gameTime);
                 zolSpriteDict.Position = Pos;
             }
         }
 
-        public void KillEnemy()
+        public void TakeDamage(Boolean stun)
         {
             zolSpriteDict.Enabled = false;
             EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyClasses/Zol.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Zol.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using MonoZelda.Collision;
 using MonoZelda.Controllers;
+using MonoZelda.Link;
 using MonoZelda.Sprites;
 
 namespace MonoZelda.Enemies.EnemyClasses
@@ -94,7 +95,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             }
         }
 
-        public void TakeDamage(Boolean stun)
+        public void TakeDamage(Boolean stun, Direction collisionDirection)
         {
             zolSpriteDict.Enabled = false;
             EnemyHitbox.UnregisterHitbox();

--- a/MonoZelda/Enemies/EnemyCollisionManager.cs
+++ b/MonoZelda/Enemies/EnemyCollisionManager.cs
@@ -9,6 +9,7 @@ namespace MonoZelda.Enemies
     {
         private int width;
         private int height;
+        private Point pos;
         private EnemyCollidable enemyHitbox;
         private CollisionController collisionController;
 
@@ -21,10 +22,10 @@ namespace MonoZelda.Enemies
             this.width = width;
             this.height = height;
 
-            Point enemyPosition = enemy.Pos;
+            pos = enemy.Pos;
             Rectangle bounds = new Rectangle(
-                (int)enemyPosition.X - width / 2,
-                (int)enemyPosition.Y - height / 2,
+                pos.X - width / 2,
+                pos.X - height / 2,
                 width,
                 height
             );
@@ -34,19 +35,19 @@ namespace MonoZelda.Enemies
             enemyHitbox.setCollisionManager(this);
         }
 
-        public void Update(int width, int height)
+        public void Update(int width, int height, Point pos)
         {
             this.width = width;
             this.height = height;
+            this.pos = pos;
             UpdateBoundingBox();
         }
 
         public void UpdateBoundingBox()
         {
-            Point enemyPosition = enemy.Pos;
             Rectangle newBounds = new Rectangle(
-                (int)enemyPosition.X - width / 2,
-                (int)enemyPosition.Y - height / 2,
+                pos.X - width / 2,
+                pos.Y - height / 2,
                 width,
                 height
             );
@@ -56,24 +57,24 @@ namespace MonoZelda.Enemies
 
         public void HandleStaticCollision(Direction collisionDirection, Rectangle intersection)
         {
-            Point currentPos = enemy.Pos;
+            pos = enemy.Pos;
             switch (collisionDirection)
             {
                 case Direction.Left:
-                    currentPos.X -= intersection.Width;
+                    pos.X -= intersection.Width;
                     break;
                 case Direction.Right:
-                    currentPos.X += intersection.Width;
+                    pos.X += intersection.Width;
                     break;
                 case Direction.Up:
-                    currentPos.Y -= intersection.Height;
+                    pos.Y -= intersection.Height;
                     break;
                 case Direction.Down:
-                    currentPos.Y += intersection.Height;
+                    pos.Y += intersection.Height;
                     break;
             }
             enemy.ChangeDirection();
-            enemy.Pos = currentPos;
+            enemy.Pos = pos;
         }
     }
 }

--- a/MonoZelda/Enemies/EnemyCollisionManager.cs
+++ b/MonoZelda/Enemies/EnemyCollisionManager.cs
@@ -72,6 +72,7 @@ namespace MonoZelda.Enemies
                     currentPos.Y += intersection.Height;
                     break;
             }
+            enemy.ChangeDirection();
             enemy.Pos = currentPos;
         }
     }

--- a/MonoZelda/Enemies/EnemyProjectiles/AquamentusFireball.cs
+++ b/MonoZelda/Enemies/EnemyProjectiles/AquamentusFireball.cs
@@ -66,10 +66,12 @@ namespace MonoZelda.Enemies.EnemyProjectiles
 
         public void ProjectileCollide()
         {
-            throw new NotImplementedException();
+            FireballSpriteDict.Enabled = false;
+            collisionController.RemoveCollidable(ProjectileHitbox);
+            ProjectileHitbox.UnregisterHitbox();
         }
 
-        public void Update(GameTime gameTime, CardinalEnemyStateMachine.Direction attackDirection, Point enemyPos)
+        public void Update(GameTime gameTime, EnemyStateMachine.Direction attackDirection, Point enemyPos)
         {
             Point pos = Pos;
             pos.X -= speed;

--- a/MonoZelda/Enemies/EnemyProjectiles/AquamentusFireball.cs
+++ b/MonoZelda/Enemies/EnemyProjectiles/AquamentusFireball.cs
@@ -64,6 +64,11 @@ namespace MonoZelda.Enemies.EnemyProjectiles
             Pos = pos;
         }
 
+        public void ProjectileCollide()
+        {
+            throw new NotImplementedException();
+        }
+
         public void Update(GameTime gameTime, CardinalEnemyStateMachine.Direction attackDirection, Point enemyPos)
         {
             Point pos = Pos;

--- a/MonoZelda/Enemies/EnemyProjectiles/EnemyProjectileCollisionManager.cs
+++ b/MonoZelda/Enemies/EnemyProjectiles/EnemyProjectileCollisionManager.cs
@@ -39,6 +39,11 @@ namespace MonoZelda.Enemies.EnemyProjectiles
             projectileHitbox.setCollisionManager(this);
         }
 
+        public void HandleCollision()
+        {
+            projectile.ProjectileCollide();
+        }
+
         public void Update()
         {
             UpdateBoundingBox();

--- a/MonoZelda/Enemies/EnemyProjectiles/GoriyaBoomerang.cs
+++ b/MonoZelda/Enemies/EnemyProjectiles/GoriyaBoomerang.cs
@@ -13,10 +13,11 @@ namespace MonoZelda.Enemies.GoriyaFolder
     {
         public Point Pos { get; set; }
         public SpriteDict BoomerangSpriteDict { get; private set; }
-        private int speed = 4;
-        private int pixelsMoved;
-        private CollisionController collisionController;
         public EnemyProjectileCollidable ProjectileHitbox { get; set; }
+        private float velocity = 360;
+        private float attackTimer;
+        private float dt;
+        private CollisionController collisionController;
 
         public GoriyaBoomerang(Point pos, ContentManager contentManager, GraphicsDevice graphicsDevice, CollisionController collisionController)
         {
@@ -41,41 +42,39 @@ namespace MonoZelda.Enemies.GoriyaFolder
         public void Follow(Point newPos)
         {
             Pos = newPos;
-            speed = Math.Abs(speed);
+            velocity = Math.Abs(velocity);
+            attackTimer = 0;
         }
 
         public void ProjectileCollide()
         {
-            speed *= -1;
+            velocity *= -1;
         }
 
         public void Update(GameTime gameTime, CardinalEnemyStateMachine.Direction attackDirection, Point enemyPos)
         {
-            var pos = new Point();
-            pos = Pos;
-            if ((Math.Abs(enemyPos.X - pos.X) <= 192 && Math.Abs(enemyPos.Y - pos.Y) <= 192 )|| speed < 0)
+            dt = (float)gameTime.ElapsedGameTime.TotalSeconds;
+            attackTimer += dt;
+            var pos = new Vector2();
+            pos = Pos.ToVector2();
+            if (attackTimer < 1 || velocity < 0)
             {
-                switch (attackDirection)
+                Vector2 movement = attackDirection switch
                 {
-                    case CardinalEnemyStateMachine.Direction.Left:
-                        pos.X -= speed;
-                        break;
-                    case CardinalEnemyStateMachine.Direction.Right:
-                        pos.X += speed;
-                        break;
-                    case CardinalEnemyStateMachine.Direction.Up:
-                        pos.Y -= speed;
-                        break;
-                    case CardinalEnemyStateMachine.Direction.Down:
-                        pos.Y += speed;
-                        break;
-                }
+                    CardinalEnemyStateMachine.Direction.Up => new Vector2(0, -1),
+                    CardinalEnemyStateMachine.Direction.Down => new Vector2(0, 1),
+                    CardinalEnemyStateMachine.Direction.Left => new Vector2(-1, 0),
+                    CardinalEnemyStateMachine.Direction.Right => new Vector2(1, 0),
+                    _ => Vector2.Zero
+                };
+                pos += (velocity * movement) * dt;
             }
             else
             {
-                speed *= -1;
+                velocity *= -1;
+                attackTimer = 0;
             }
-            Pos = pos;
+            Pos = pos.ToPoint();
             BoomerangSpriteDict.Position = Pos;
         }
     }

--- a/MonoZelda/Enemies/EnemyProjectiles/GoriyaBoomerang.cs
+++ b/MonoZelda/Enemies/EnemyProjectiles/GoriyaBoomerang.cs
@@ -51,7 +51,7 @@ namespace MonoZelda.Enemies.GoriyaFolder
             velocity *= -1;
         }
 
-        public void Update(GameTime gameTime, CardinalEnemyStateMachine.Direction attackDirection, Point enemyPos)
+        public void Update(GameTime gameTime, EnemyStateMachine.Direction attackDirection, Point enemyPos)
         {
             dt = (float)gameTime.ElapsedGameTime.TotalSeconds;
             attackTimer += dt;
@@ -61,10 +61,10 @@ namespace MonoZelda.Enemies.GoriyaFolder
             {
                 Vector2 movement = attackDirection switch
                 {
-                    CardinalEnemyStateMachine.Direction.Up => new Vector2(0, -1),
-                    CardinalEnemyStateMachine.Direction.Down => new Vector2(0, 1),
-                    CardinalEnemyStateMachine.Direction.Left => new Vector2(-1, 0),
-                    CardinalEnemyStateMachine.Direction.Right => new Vector2(1, 0),
+                    EnemyStateMachine.Direction.Up => new Vector2(0, -1),
+                    EnemyStateMachine.Direction.Down => new Vector2(0, 1),
+                    EnemyStateMachine.Direction.Left => new Vector2(-1, 0),
+                    EnemyStateMachine.Direction.Right => new Vector2(1, 0),
                     _ => Vector2.Zero
                 };
                 pos += (velocity * movement) * dt;

--- a/MonoZelda/Enemies/EnemyProjectiles/GoriyaBoomerang.cs
+++ b/MonoZelda/Enemies/EnemyProjectiles/GoriyaBoomerang.cs
@@ -31,7 +31,7 @@ namespace MonoZelda.Enemies.GoriyaFolder
         public void ViewProjectile(bool view, bool goriyaAlive)
         {
             BoomerangSpriteDict.Enabled = view;
-            if(goriyaAlive == false)
+            if(!goriyaAlive)
             {
                 collisionController.RemoveCollidable(ProjectileHitbox);
                 ProjectileHitbox.UnregisterHitbox();
@@ -42,6 +42,11 @@ namespace MonoZelda.Enemies.GoriyaFolder
         {
             Pos = newPos;
             speed = Math.Abs(speed);
+        }
+
+        public void ProjectileCollide()
+        {
+            speed *= -1;
         }
 
         public void Update(GameTime gameTime, CardinalEnemyStateMachine.Direction attackDirection, Point enemyPos)

--- a/MonoZelda/Enemies/EnemyProjectiles/IEnemyProjectile.cs
+++ b/MonoZelda/Enemies/EnemyProjectiles/IEnemyProjectile.cs
@@ -13,5 +13,5 @@ public interface IEnemyProjectile
 
     public void ProjectileCollide();
 
-    public void Update(GameTime gameTime, CardinalEnemyStateMachine.Direction attackDirection, Point enemyPos);
+    public void Update(GameTime gameTime, EnemyStateMachine.Direction attackDirection, Point enemyPos);
 }

--- a/MonoZelda/Enemies/EnemyProjectiles/IEnemyProjectile.cs
+++ b/MonoZelda/Enemies/EnemyProjectiles/IEnemyProjectile.cs
@@ -11,5 +11,7 @@ public interface IEnemyProjectile
     public void ViewProjectile(bool view, bool enemyAlive);
     public void Follow(Point newPos);
 
+    public void ProjectileCollide();
+
     public void Update(GameTime gameTime, CardinalEnemyStateMachine.Direction attackDirection, Point enemyPos);
 }

--- a/MonoZelda/Enemies/EnemyStateMachine.cs
+++ b/MonoZelda/Enemies/EnemyStateMachine.cs
@@ -4,18 +4,18 @@ using MonoZelda.Link;
 
 namespace MonoZelda.Enemies
 {
-    public class CardinalEnemyStateMachine
+    public class EnemyStateMachine
     {
         //states
-        public enum Direction { Left, Right, Up, Down, None }
+        public enum Direction { Left, Right, Up, Down, UpLeft, UpRight, DownLeft, DownRight, None }
         private Direction direction = Direction.None;
-        private bool spawning;
+        public bool Spawning {get; set; }
         public bool Dead { get; set; }
-        private bool knockback = false;
+        private bool knockback;
 
         //not states
         private const float KNOCKBACK_FORCE = 1000f;
-        private float velocity = 60f;
+        private float velocity = 120;
         private float dt;
         private double animationTimer;
         private float knockbackTimer;
@@ -25,10 +25,10 @@ namespace MonoZelda.Enemies
         private Vector2 movement;
         public Point currentPosition { get; private set; }
 
-        public CardinalEnemyStateMachine(SpriteDict spriteDict)
+        public EnemyStateMachine(SpriteDict spriteDict)
         {
             enemySpriteDict = spriteDict;
-            spawning = true;
+            Spawning = true;
             Dead = false;
             animationTimer = 0;
             enemySpriteDict.SetSprite("cloud");
@@ -81,20 +81,20 @@ namespace MonoZelda.Enemies
                 knockbackTimer += dt;
                 if (knockbackTimer >= 0.05)
                 {
-                    velocity = 60;
+                    velocity = 120;
                     knockback = false;
                     knockbackTimer = 0;
                 }
                 enemyPosition += (KNOCKBACK_FORCE * knockbackDirection) * dt;
                 enemySpriteDict.SetSprite("gel_turquoise");
             }
-            else if (spawning)
+            else if (Spawning)
             {
                 animationTimer += dt;
                 if (animationTimer >= 1)
                 {
                     enemy.ChangeDirection();
-                    spawning = false;
+                    Spawning = false;
                 }
             }
             else if (Dead)
@@ -114,6 +114,10 @@ namespace MonoZelda.Enemies
                     Direction.Down => new Vector2(0, 1),
                     Direction.Left => new Vector2(-1, 0),
                     Direction.Right => new Vector2(1, 0),
+                    Direction.UpLeft => new Vector2(-1, -1),
+                    Direction.UpRight => new Vector2(1, -1),
+                    Direction.DownLeft => new Vector2(-1, 1),
+                    Direction.DownRight => new Vector2(1, 1),
                     _ => Vector2.Zero
                 };
                 enemyPosition += (velocity * movement)*dt;

--- a/MonoZelda/Enemies/IEnemy.cs
+++ b/MonoZelda/Enemies/IEnemy.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using MonoZelda.Collision;
 using MonoZelda.Controllers;
+using MonoZelda.Link;
 using MonoZelda.Sprites;
 
 namespace MonoZelda.Enemies
@@ -25,7 +26,7 @@ namespace MonoZelda.Enemies
 
         public void Update(GameTime gameTime);
 
-        public void TakeDamage(Boolean stun);
+        public void TakeDamage(Boolean stun, Direction collisionDirection);
         
     }
 }

--- a/MonoZelda/Enemies/IEnemy.cs
+++ b/MonoZelda/Enemies/IEnemy.cs
@@ -17,13 +17,15 @@ namespace MonoZelda.Enemies
 
         public int Height { get; set; }
 
+        public Boolean Alive { get; set; }
+
         public void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ContentManager contentManager);
 
         public void ChangeDirection();
 
         public void Update(GameTime gameTime);
 
-        public void KillEnemy();
+        public void TakeDamage(Boolean stun);
         
     }
 }

--- a/MonoZelda/Scenes/DungeonScene.cs
+++ b/MonoZelda/Scenes/DungeonScene.cs
@@ -167,6 +167,11 @@ public class DungeonScene : IScene
 
         foreach(KeyValuePair<IEnemy, EnemyCollisionManager> entry in enemyDictionary)
         {
+            if (!entry.Key.Alive) // remove dead enemies from lists (hopefully this is useful for re-entering rooms)
+            {
+                enemies.Remove(entry.Key);
+                enemyDictionary.Remove(entry.Key);
+            }
             entry.Key.Update(gameTime);
             entry.Value.Update(entry.Key.Width, entry.Key.Height);
         }

--- a/MonoZelda/Scenes/DungeonScene.cs
+++ b/MonoZelda/Scenes/DungeonScene.cs
@@ -14,6 +14,7 @@ using MonoZelda.Enemies;
 using System.Collections.Generic;
 using MonoZelda.Enemies.EnemyProjectiles;
 using MonoZelda.Commands.CollisionCommands;
+using MonoZelda.Enemies.EnemyClasses;
 using MonoZelda.Trigger;
 
 namespace MonoZelda.Scenes;
@@ -173,7 +174,14 @@ public class DungeonScene : IScene
                 enemyDictionary.Remove(entry.Key);
             }
             entry.Key.Update(gameTime);
-            entry.Value.Update(entry.Key.Width, entry.Key.Height);
+            if (entry.Key.GetType() == typeof(Aquamentus))
+            {
+                entry.Value.Update(entry.Key.Width, entry.Key.Height, new Point(entry.Key.Pos.X - 16, entry.Key.Pos.Y - 16));
+            }
+            else
+            {
+                entry.Value.Update(entry.Key.Width, entry.Key.Height, entry.Key.Pos);
+            }
         }
 
         playerCollision.Update();


### PR DESCRIPTION
### NEW
- Damage/Stun for all enemies (except trap)
- knockback for enemies that have it
- Collision handling for enemy projectiles (boomerangs return, fireballs are destroyed)

### CHANGED
- Single EnemyStateMachine for all enemies (keese was the only one using a different one before)
- Changed the way enemies handle static collisions (should prevent enemies from just walking into walls for a few seconds)
- Moved spawn and death handling into state machines
- Vector and dt based movement in state machine for enemies
- Moved Aquamentus hitbox to head/neck area

### UNFINISHED/BUGS/UNFORTUNATE SIDE EFFECTS
- Enemy knockback will sometimes go in the wrong direction (collision detection is giving wrong direction)
- Player aware enemies still unfinished
- Enemies no longer stay centered on tiles/ only change direction when on the center of a tile. (I think this would be a pretty big task to fix and doesn't seem that worth it to me, seems to kind of happen in the actual game anyway)
- My classes are getting really long