### PR TITLE
Carson flashing sprites

### DIFF
--- a/MonoZelda/Collision/CollisionHitboxDraw.cs
+++ b/MonoZelda/Collision/CollisionHitboxDraw.cs
@@ -16,7 +16,7 @@ namespace MonoZelda.Collision
         {
             this.collidable = collidable;
             texture = TextureData.GetTexture(SpriteType.Blank);
-            SpriteDrawer.RegisterDrawable(this, int.MaxValue, true);
+            SpriteDrawer.RegisterDrawable(this, SpriteLayer.Gizmos, true);
         }
 
         ~CollisionHitboxDraw() {

--- a/MonoZelda/Collision/CollisionHitboxDraw.cs
+++ b/MonoZelda/Collision/CollisionHitboxDraw.cs
@@ -28,7 +28,7 @@ namespace MonoZelda.Collision
             SpriteDrawer.UnregisterDrawable(this);
         }
 
-        public void Draw(SpriteBatch spriteBatch, GameTime gameTime)
+        public void Draw(SpriteBatch spriteBatch)
         {
             Rectangle Bounds = collidable.Bounds;
             spriteBatch.Draw(texture, new Rectangle(Bounds.Left, Bounds.Top, Bounds.Width, Thickness), GizmoColor);

--- a/MonoZelda/Content/Source Rect CSVs/Sprite Source Rects - Projectiles.csv
+++ b/MonoZelda/Content/Source Rect CSVs/Sprite Source Rects - Projectiles.csv
@@ -12,6 +12,7 @@ boomerang,80,256,8,8,8,center,10
 boomerang_blue,80,264,8,8,8,center,10
 bomb,144,256,16,16,1,center,10
 cloud,160,256,16,16,3,center,10
+cloud_slow,160,256,16,16,3,center,4
 fire,208,256,16,16,2,center,10
 woodensword_item_up,0,224,8,16,1,center,10
 woodensword_item_down,8,224,8,16,1,center,10

--- a/MonoZelda/Controllers/KeyboardController.cs
+++ b/MonoZelda/Controllers/KeyboardController.cs
@@ -40,7 +40,8 @@ public class KeyboardController : IController
             {new (Keys.Q, false), CommandType.ExitCommand},
             {new (Keys.R, false), CommandType.ResetCommand},
             {new (Keys.None, false), CommandType.PlayerStandingCommand},
-            {new (Keys.I, true), CommandType.ToggleInventoryCommand}
+            {new (Keys.I, true), CommandType.ToggleInventoryCommand},
+            {new (Keys.Escape, true), CommandType.ToggleInventoryCommand},
         };
     }
 

--- a/MonoZelda/Enemies/Enemy.cs
+++ b/MonoZelda/Enemies/Enemy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Microsoft.Xna.Framework;
 using MonoZelda.Collision;
 using MonoZelda.Controllers;
@@ -126,7 +127,9 @@ namespace MonoZelda.Enemies
                 if (Health > 0)
                 {
                     SoundManager.PlaySound("LOZ_Enemy_Hit", false);
-                    StateMachine.Knockback(true, collisionDirection);
+                    StateMachine.DamageFlash();
+                    StateMachine.Knockback(true, PlayerState.Direction);
+                    Debug.WriteLine(PlayerState.Direction);
                 }
                 else
                 {

--- a/MonoZelda/Enemies/Enemy.cs
+++ b/MonoZelda/Enemies/Enemy.cs
@@ -128,8 +128,7 @@ namespace MonoZelda.Enemies
                 {
                     SoundManager.PlaySound("LOZ_Enemy_Hit", false);
                     StateMachine.DamageFlash();
-                    StateMachine.Knockback(true, PlayerState.Direction);
-                    Debug.WriteLine(PlayerState.Direction);
+                    StateMachine.Knockback(true, collisionDirection);
                 }
                 else
                 {

--- a/MonoZelda/Enemies/EnemyStateMachine.cs
+++ b/MonoZelda/Enemies/EnemyStateMachine.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Microsoft.Xna.Framework;
 using MonoZelda.Enemies.EnemyClasses;
 using MonoZelda.Items;
@@ -9,6 +10,7 @@ namespace MonoZelda.Enemies
 {
     public class EnemyStateMachine
     {
+
         //states
         public enum Direction { Left, Right, Up, Down, UpLeft, UpRight, DownLeft, DownRight, None }
         private Direction direction = Direction.None;
@@ -18,6 +20,7 @@ namespace MonoZelda.Enemies
 
         //not states
         private const float KNOCKBACK_FORCE = 1000f;
+        private const float DAMAGE_FLASH_TIME = .5f;
         private float velocity = 120;
         private float dt;
         private double animationTimer;
@@ -53,6 +56,11 @@ namespace MonoZelda.Enemies
         public void SetSprite(string newSprite)
         {
             currentSprite = newSprite;
+        }
+
+        public void DamageFlash()
+        {
+            enemySpriteDict.SetFlashing(SpriteDict.FlashingType.Colorful, DAMAGE_FLASH_TIME);
         }
 
         public void ChangeSpeed(float newSpeed)

--- a/MonoZelda/Items/ItemFactory.cs
+++ b/MonoZelda/Items/ItemFactory.cs
@@ -9,7 +9,9 @@ using System;
 namespace MonoZelda.Items;
 
 public class ItemFactory
-{ 
+{
+    private const float FLASHING_TIME = .75f;
+
     private CollisionController collisionController;
 
     public ItemFactory( CollisionController collisionController)
@@ -20,6 +22,7 @@ public class ItemFactory
     public void CreateItem(ItemList itemName, Point spawnPosition)
     {
         var itemDict = new SpriteDict(SpriteType.Items, 0, new Point(0, 0));
+        itemDict.SetFlashing(SpriteDict.FlashingType.OnOff, FLASHING_TIME);
         var itemType = Type.GetType($"MonoZelda.Items.ItemClasses.{itemName}");
         IItem item = (IItem)Activator.CreateInstance(itemType);
         item.itemSpawn(itemDict, spawnPosition, collisionController);

--- a/MonoZelda/Link/PlayerSpriteManager.cs
+++ b/MonoZelda/Link/PlayerSpriteManager.cs
@@ -15,11 +15,14 @@ public enum Direction {
 
 public class PlayerSpriteManager
 {
+    private const float DAMAGE_FLASH_TIME = .5f;
+    private const float DAMAGE_IMMOBILITY_TIME = .2f;
+
     private Direction playerDirection;
     private SpriteDict playerSpriteDict;
     private Vector2 playerPosition;
     private float playerSpeed = 6.0f;
-    private double timer;
+    private double immobilityTimer;
 
     private static readonly Dictionary<Direction, string> DirectionToStringMap = new()
     {
@@ -59,8 +62,8 @@ public class PlayerSpriteManager
 
     public void Move(PlayerMoveCommand moveCommand)
     {
-        if (timer > 0) {
-            timer -= MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
+        if (immobilityTimer > 0) {
+            immobilityTimer -= MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
             return;
         }
 
@@ -84,7 +87,7 @@ public class PlayerSpriteManager
         
     public void StandStill(PlayerStandingCommand standCommand)
     {
-        if (timer <= 0)
+        if (immobilityTimer <= 0)
         {
             // Get direction string from the dictionary
             if (DirectionToStringMap.TryGetValue(playerDirection, out string directionString))
@@ -94,7 +97,7 @@ public class PlayerSpriteManager
             }
         }
         else {
-            timer -= MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
+            immobilityTimer -= MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
         }
         playerSpriteDict.Position = playerPosition.ToPoint();
         PlayerState.Position = playerPosition.ToPoint();
@@ -102,59 +105,59 @@ public class PlayerSpriteManager
 
     public void PlayerDeath()
     {
-        if (timer <= 0)
+        if (immobilityTimer <= 0)
         {
             string spriteName = "hurt_down";
             playerSpriteDict.SetSprite(spriteName);
-            timer = playerSpriteDict.SetSpriteOneshot(spriteName);
+            immobilityTimer = playerSpriteDict.SetSpriteOneshot(spriteName);
         }
         else
         {
-            timer -= MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
+            immobilityTimer -= MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
         }
     }
 
     public void Attack()
     {
-        if (timer <= 0)
+        if (immobilityTimer <= 0)
         {
             // Get direction string from the dictionary
             if (DirectionToStringMap.TryGetValue(playerDirection, out string directionString))
             {
                 string spriteName = $"woodensword_{directionString}";
-                timer = playerSpriteDict.SetSpriteOneshot(spriteName);
+                immobilityTimer = playerSpriteDict.SetSpriteOneshot(spriteName);
             }
         }
         else {
-            timer -= MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
+            immobilityTimer -= MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
         }
     }
 
     public void UseItem()
     {
-        if(timer <= 0)
+        if(immobilityTimer <= 0)
         {
             // Get direction string from the dictionary
             if (DirectionToStringMap.TryGetValue(playerDirection, out string directionString))
             {
                 string spriteName = $"useitem_{directionString}";
-                timer = playerSpriteDict.SetSpriteOneshot(spriteName);
+                immobilityTimer = playerSpriteDict.SetSpriteOneshot(spriteName);
             }
         } 
         else {
-            timer -= MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
+            immobilityTimer -= MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
         }
     }
 
     public void TakeDamage()
     {
-        if (timer <= 0)
+        if (immobilityTimer <= 0)
         {
             // Get direction string from the dictionary
             if (DirectionToStringMap.TryGetValue(playerDirection, out string directionString))
             {
-                string spriteName = $"hurt_{directionString}";
-                timer = playerSpriteDict.SetSpriteOneshot(spriteName);
+                playerSpriteDict.SetFlashing(SpriteDict.FlashingType.Colorful, DAMAGE_FLASH_TIME);
+                immobilityTimer = DAMAGE_IMMOBILITY_TIME;
             }
         }
        

--- a/MonoZelda/Link/PlayerState.cs
+++ b/MonoZelda/Link/PlayerState.cs
@@ -32,17 +32,6 @@ public static class PlayerState
 
     public static void ResetCandle()
     {
-        _health = INITIAL_HP;
-        IsCandleUsed = false;
-    }
-
-    public static void ChangeRoom()
-    {
-        _health = INITIAL_HP;
-        Rupees = INITIAL_RUPEES;
-        Bombs = INITIAL_BOMBS;
-        Keys = INITIAL_KEYS;
-
         IsCandleUsed = false;
     }
 

--- a/MonoZelda/Link/PlayerState.cs
+++ b/MonoZelda/Link/PlayerState.cs
@@ -7,7 +7,11 @@ namespace MonoZelda.Link;
 
 public static class PlayerState
 {
-    private static int INITIAL_HP =6;
+    private static readonly int INITIAL_HP = 6;
+    private static readonly int INITIAL_RUPEES = 3;
+    private static readonly int INITIAL_BOMBS = 1;
+    private static readonly int INITIAL_KEYS = 0;
+
     private static int _health = INITIAL_HP;
 
     public static void Initialize()
@@ -19,9 +23,9 @@ public static class PlayerState
         IsKnockedBack = false;
         _health = INITIAL_HP;
         MaxHealth = INITIAL_HP;
-        Rupees = 0;
-        Bombs = 0;
-        Keys = 0;
+        Rupees = INITIAL_RUPEES;
+        Bombs = INITIAL_BOMBS;
+        Keys = INITIAL_KEYS;
         EquippedProjectile = ProjectileType.None;
 
 

--- a/MonoZelda/Link/PlayerState.cs
+++ b/MonoZelda/Link/PlayerState.cs
@@ -29,9 +29,15 @@ public static class PlayerState
     }
     public static void ResetCandle()
     {
+        _health = INITIAL_HP;
         IsCandleUsed = false;
     }
-    
+
+    public static void ChangeRoom()
+    {
+        IsCandleUsed = false;
+    }
+
     public static int Health
     {
         get => _health;

--- a/MonoZelda/Link/PlayerState.cs
+++ b/MonoZelda/Link/PlayerState.cs
@@ -28,9 +28,8 @@ public static class PlayerState
         Keys = INITIAL_KEYS;
         EquippedProjectile = ProjectileType.None;
 
-
-
     }
+
     public static void ResetCandle()
     {
         _health = INITIAL_HP;
@@ -44,11 +43,6 @@ public static class PlayerState
         Bombs = INITIAL_BOMBS;
         Keys = INITIAL_KEYS;
 
-        IsCandleUsed = false;
-    }
-
-    public static void ChangeRoom()
-    {
         IsCandleUsed = false;
     }
 

--- a/MonoZelda/Link/Projectiles/Bomb/Bomb.cs
+++ b/MonoZelda/Link/Projectiles/Bomb/Bomb.cs
@@ -1,39 +1,52 @@
 ﻿using MonoZelda.Sprites;
 using Microsoft.Xna.Framework;
 using MonoZelda.Sound;
+using System.Diagnostics;
 
 namespace MonoZelda.Link.Projectiles;
 
 public class Bomb : ProjectileFactory, IProjectile
 {
-    private bool Finished;
-    private int timer;
-    private const int EXPLODE_TIME = 90;
-    private Vector2 InitialPosition;
-    private Vector2 Dimension = new Vector2(8, 16);
+    private const float EXPLODE_TIME = 1.5f;
+
+    private static readonly Point[] explosionCloudPositions = new Point[] {
+        new(-64, 0),
+        new(-32, 64),
+        new(32, 64),
+        new(64, 0),
+        new(32, -64),
+        new(-32, -64),
+    };
+
+    private bool finished;
+    private float explosionTimer;
+    private float animationTimer;
+    private Vector2 initialPosition;
+    private Vector2 dimension = new Vector2(8, 16);
     private SpriteDict projectileDict;
+    private SpriteDict[] explosionSpriteDicts;
     private bool exploded;
+
     public bool Exploded
     {
         get => exploded;
-        set => exploded = value;
     }
 
     public Bomb(SpriteDict projectileDict, Vector2 playerPosition, Direction playerDirection)
     : base(projectileDict, playerPosition, playerDirection)
     {
         this.projectileDict = projectileDict;
-        Finished = false;
-        timer = 0;
-        InitialPosition = SetInitialPosition(Dimension);
+        finished = false;
+        explosionTimer = EXPLODE_TIME;
+        initialPosition = SetInitialPosition(dimension);
         SetProjectileSprite("bomb");
-        projectileDict.Position = InitialPosition.ToPoint();
-        Exploded = false;
+        projectileDict.Position = initialPosition.ToPoint();
+        exploded = false;
     }
 
     public bool hasFinished()
     {
-        return Finished;
+        return finished;
     }
 
     public void FinishProjectile()
@@ -49,18 +62,43 @@ public class Bomb : ProjectileFactory, IProjectile
 
     public void UpdateProjectile()
     {
-        if (timer >= EXPLODE_TIME && timer < 100)
+        if (explosionTimer <= 0f && !exploded)
         {
-            SoundManager.PlaySound("LOZ_Bomb_Blow", false);
-            SetProjectileSprite("cloud");
-            Exploded = true;
+            Explode();
         }
-        else if(timer == 100)
+
+        if(animationTimer <= 0f && exploded)
         {
-            Finished = true;
-            projectileDict.SetSprite("");
+            finished = true;
+
+            //clean up spritedicts
             projectileDict.Enabled = false;
+            for (int i = 0; i < explosionSpriteDicts.Length; i++) {
+                explosionSpriteDicts[i].Unregister();
+                explosionSpriteDicts[i] = null;
+            }
         }
-        timer++;
+
+        if (explosionTimer > 0f)
+            explosionTimer -= (float) MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
+        if (animationTimer > 0f)
+            animationTimer -= (float) MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
+    }
+
+    private void Explode() {
+        exploded = true;
+        SoundManager.PlaySound("LOZ_Bomb_Blow", false);
+        animationTimer = (float) projectileDict.SetSpriteOneshot("cloud_slow");
+
+        //set up explosion clouds
+        explosionSpriteDicts = new SpriteDict[6];
+        for (int i = 0; i < explosionSpriteDicts.Length; i++) {
+            explosionSpriteDicts[i] = new(SpriteType.Projectiles, SpriteLayer.Projectiles, initialPosition.ToPoint() + explosionCloudPositions[i]);
+            explosionSpriteDicts[i].SetSprite("cloud_slow");
+            explosionSpriteDicts[i].FlashingRate = 30f;
+            explosionSpriteDicts[i].SetFlashing(SpriteDict.FlashingType.OnOff, animationTimer);
+        }
+        BlankSprite bs = new(SpriteLayer.Gizmos, new Point(0, 193), new Point(1024, 704), new Color(.75f, .75f, .75f, .75f));
+        bs.FadeOut(animationTimer);
     }
 }

--- a/MonoZelda/MonoZeldaGame.cs
+++ b/MonoZelda/MonoZeldaGame.cs
@@ -139,7 +139,6 @@ public class MonoZeldaGame : Game
     public void ResetGame()
     {
         SoundManager.ClearSoundDictionary();
-        PlayerState.Reset();
         LoadScene(new MainMenuScene(GraphicsDevice));
     }
 }

--- a/MonoZelda/Scenes/EnterDungeonScene.cs
+++ b/MonoZelda/Scenes/EnterDungeonScene.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using Microsoft.VisualBasic;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using MonoZelda.Dungeons;
@@ -12,8 +13,8 @@ namespace MonoZelda.Scenes
         private GraphicsDevice gd;
         private DungeonScene scene;
 
-        private SpriteDict leftCurtain;
-        private SpriteDict rightCurtain;
+        private BlankSprite leftCurtain;
+        private BlankSprite rightCurtain;
 
         private int delay;
 
@@ -27,7 +28,7 @@ namespace MonoZelda.Scenes
         public override void LoadContent(ContentManager contentManager)
         {
             // center of the creen
-            var center = new Point(gd.Viewport.Width / 2, DungeonConstants.RoomPosition.Y);
+            var center = new Point(gd.Viewport.Width / 2, DungeonConstants.RoomPosition.Y - 64);
 
             // Fake the dungeon entrance
             // Room wall border
@@ -41,11 +42,9 @@ namespace MonoZelda.Scenes
 
             // the room texutres are 192 * 4 = 768 pixels wide
             var leftPosition = center - new Point(192 * 4, 0);
-            leftCurtain = new SpriteDict(SpriteType.Blocks, SpriteLayer.HUD, leftPosition);
-            leftCurtain.SetSprite(nameof(Dungeon1Sprite.room_41));
-
-            rightCurtain = new SpriteDict(SpriteType.Blocks, SpriteLayer.HUD, center);
-            rightCurtain.SetSprite(nameof(Dungeon1Sprite.room_41));
+            var curtainSize = new Point(192 * 4, 176 * 4);
+            leftCurtain = new BlankSprite(SpriteLayer.HUD, leftPosition, curtainSize, Color.Black);
+            rightCurtain = new BlankSprite(SpriteLayer.HUD, center, curtainSize, Color.Black);
 
             CreateFakeDoors(room);
         }
@@ -62,7 +61,7 @@ namespace MonoZelda.Scenes
         public override void Update(GameTime gameTime)
         {
             // It takes a few frames before the textures load
-            if(delay < 15)
+            if(delay < 20)
             {
                 delay++;
                 return;

--- a/MonoZelda/Sprites/BlankSprite.cs
+++ b/MonoZelda/Sprites/BlankSprite.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace MonoZelda.Sprites;
+
+public class BlankSprite : IDrawable
+{
+    private enum FadeMode {
+        In,
+        Out,
+        None,
+    }
+
+    /// <summary>
+    /// The screen position to draw this SpriteDict at.
+    /// </summary>
+    public Point Position { get; set; }
+    /// <summary>
+    /// Determines whether the sprite is drawn or not.
+    /// </summary>
+    public bool Enabled { get; set; }
+    /// <summary>
+    /// Pixel size of this BlankSprite.
+    /// </summary>
+    public Point Size { get; set; }
+    /// <summary>
+    /// Color of this BlankSprite.
+    /// </summary>
+    public Color BaseColor { get; set; }
+
+    private readonly Texture2D texture;
+    private FadeMode fadeMode = FadeMode.None;
+    private float fadeTimer;
+    private float totalFadeTime;
+
+    public BlankSprite(int priority, Point position, Point size)
+    {
+        this.texture = TextureData.GetTexture(SpriteType.Blank);
+        Position = position;
+        Size = size;
+        this.Enabled = true;
+        this.BaseColor = Color.White;
+        SpriteDrawer.RegisterDrawable(this, priority);
+    }
+
+    public BlankSprite(int priority, Point position, Point size, Color baseColor) {
+        this.texture = TextureData.GetTexture(SpriteType.Blank);
+        Position = position;
+        Size = size;
+        this.Enabled = true;
+        this.BaseColor = baseColor;
+        SpriteDrawer.RegisterDrawable(this, priority);
+    }
+
+    ~BlankSprite() {
+        Unregister();
+    }
+
+    public void Unregister() {
+        SpriteDrawer.UnregisterDrawable(this);
+    }
+
+    public void FadeOut(float time) {
+        fadeMode = FadeMode.Out;
+        totalFadeTime = time;
+        fadeTimer = time;
+    }
+
+    public void FadeIn(float time) {
+        Enabled = true;
+        fadeMode = FadeMode.In;
+        totalFadeTime = time;
+        fadeTimer = time;
+    }
+
+    public void Draw(SpriteBatch spriteBatch)
+    {
+        //do nothing if disabled
+        if (!Enabled) {
+            return;
+        }
+
+        //calculate color
+        Vector4 drawColor = BaseColor.ToVector4();
+        switch (fadeMode) {
+            case FadeMode.In: {
+                float t = 1f - fadeTimer / totalFadeTime;
+                drawColor = Vector4.Lerp(Vector4.Zero, BaseColor.ToVector4(), t);
+                break;
+            }
+            case FadeMode.Out: {
+                float t = 1f - fadeTimer / totalFadeTime;
+                drawColor = Vector4.Lerp(BaseColor.ToVector4(), Vector4.Zero, t);
+                break;
+            }
+        }
+
+        //create destination rectangle
+        Rectangle destRect = new(Position, Size);
+
+        //draw current sprite
+        spriteBatch.Draw(texture, destRect, new Color(drawColor));
+
+        if (fadeTimer > 0f) {
+            fadeTimer -= (float) MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
+        }
+        else {
+            if (fadeMode == FadeMode.Out) {
+                Enabled = false;
+            }
+            fadeMode = FadeMode.None;
+        }
+    }
+}

--- a/MonoZelda/Sprites/IDrawable.cs
+++ b/MonoZelda/Sprites/IDrawable.cs
@@ -3,5 +3,5 @@ using Microsoft.Xna.Framework.Graphics;
 
 public interface IDrawable
 {
-	public void Draw(SpriteBatch spriteBatch, GameTime gameTime);
+	public void Draw(SpriteBatch spriteBatch);
 }

--- a/MonoZelda/Sprites/Sprite.cs
+++ b/MonoZelda/Sprites/Sprite.cs
@@ -53,14 +53,14 @@ public class Sprite
         return FrameCount / Fps - buffer;
     }
 
-    public void Draw(SpriteBatch spriteBatch, GameTime gameTime, Texture2D texture, Point position)
+    public void Draw(SpriteBatch spriteBatch, Texture2D texture, Point position, Color color)
     {
         //calculate source rect based on gameTime to support animation
         double animationTime;
         if (oneshotPlaying) {
             //oneshot timer
             animationTime = oneshotTimer;
-            oneshotTimer += gameTime.ElapsedGameTime.TotalSeconds;
+            oneshotTimer += MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
             //end oneshot animation 
             if (oneshotTimer >= FrameCount / Fps) {
                 oneshotPlaying = false;
@@ -68,7 +68,7 @@ public class Sprite
         }
         else if (Animating) {
             //global timer
-            animationTime = gameTime.TotalGameTime.TotalSeconds;
+            animationTime = MonoZeldaGame.GameTime.TotalGameTime.TotalSeconds;
         }
         else {
             //not animating
@@ -83,7 +83,7 @@ public class Sprite
         Rectangle destinationRect = new(destRectPos, destRectSize.ToPoint());
 
         //draw the sprite
-        spriteBatch.Draw(texture, destinationRect, currentSource, Color.White);
+        spriteBatch.Draw(texture, destinationRect, currentSource, color);
     }
 
     private static Vector2 GetNormalizedAnchorOffset(AnchorType anchorType)

--- a/MonoZelda/Sprites/SpriteData.cs
+++ b/MonoZelda/Sprites/SpriteData.cs
@@ -84,3 +84,12 @@ internal static class SpriteCSVData
     }
 }
 
+internal static class ColorData
+{
+    public static Color White { get; private set; } = new Color(1f, 1f, 1f, 1f);
+    public static Color Red { get; private set; } = new Color(1f, .5f, .5f, 1f);
+    public static Color Green { get; private set; } = new Color(.5f, 1f, .5f, 1f);
+    public static Color Blue { get; private set; } = new Color(.5f, .5f, 1f, 1f);
+    public static Color Transparent { get; private set; } = new Color(0f, 0f, 0f, 0f);
+}
+

--- a/MonoZelda/Sprites/SpriteDict.cs
+++ b/MonoZelda/Sprites/SpriteDict.cs
@@ -14,15 +14,24 @@ public class SpriteDict : IDrawable
         Colorful,
     }
 
-    private const float FLASHING_RATE = 20f;
-    private static Dictionary<FlashingType, List<Color>> flashingColors = new Dictionary<FlashingType, List<Color>> {
+    private static Dictionary<FlashingType, List<Color>> flashingColors = new() {
         { FlashingType.OnOff, new List<Color> { ColorData.White, ColorData.Transparent } },
         { FlashingType.Red, new List<Color> { ColorData.White, ColorData.Red } },
         { FlashingType.Colorful, new List<Color> { ColorData.Blue, ColorData.Red, ColorData.Green, ColorData.White } },
     };
 
+    /// <summary>
+    /// The screen position to draw this SpriteDict at.
+    /// </summary>
     public Point Position { get; set; }
+    /// <summary>
+    /// Determines whether the sprite is drawn or not.
+    /// </summary>
     public bool Enabled { get; set; }
+    /// <summary>
+    /// Rate that colors change when flashing (per second).
+    /// </summary>
+    public float FlashingRate { get; set; } = 20f;
 
     private readonly Texture2D texture;
     private readonly Dictionary<string, Sprite> dict = new();
@@ -88,6 +97,6 @@ public class SpriteDict : IDrawable
         if (flashingTimer <= 0f) {
             return ColorData.White;
         }
-        return flashingColors[flashingType][(int) (flashingTimer * FLASHING_RATE % flashingColors[flashingType].Count)];
+        return flashingColors[flashingType][(int) (flashingTimer * FlashingRate % flashingColors[flashingType].Count)];
     }
 }

--- a/MonoZelda/Sprites/SpriteDict.cs
+++ b/MonoZelda/Sprites/SpriteDict.cs
@@ -90,7 +90,9 @@ public class SpriteDict : IDrawable
         //draw current sprite
         dict[currentSprite].Draw(spriteBatch, texture, Position, GetColor());
 
-        flashingTimer -= (float) MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
+        if (flashingTimer > 0f) {
+            flashingTimer -= (float) MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
+        }
     }
 
     private Color GetColor() {

--- a/MonoZelda/Sprites/SpriteDict.cs
+++ b/MonoZelda/Sprites/SpriteDict.cs
@@ -7,12 +7,28 @@ namespace MonoZelda.Sprites;
 
 public class SpriteDict : IDrawable
 {
+    public enum FlashingType
+    {
+        OnOff,
+        Red,
+        Colorful,
+    }
+
+    private const float FLASHING_RATE = 20f;
+    private static Dictionary<FlashingType, List<Color>> flashingColors = new Dictionary<FlashingType, List<Color>> {
+        { FlashingType.OnOff, new List<Color> { ColorData.White, ColorData.Transparent } },
+        { FlashingType.Red, new List<Color> { ColorData.White, ColorData.Red } },
+        { FlashingType.Colorful, new List<Color> { ColorData.Blue, ColorData.Red, ColorData.Green, ColorData.White } },
+    };
+
     public Point Position { get; set; }
     public bool Enabled { get; set; }
 
     private readonly Texture2D texture;
     private readonly Dictionary<string, Sprite> dict = new();
     private string currentSprite = "";
+    private FlashingType flashingType;
+    private float flashingTimer;
 
     public SpriteDict(SpriteType spriteType, int priority, Point position)
     {
@@ -49,7 +65,13 @@ public class SpriteDict : IDrawable
         return dict[currentSprite].SetOneshot(true);
     }
 
-    public void Draw(SpriteBatch spriteBatch, GameTime gameTime)
+    public void SetFlashing(FlashingType type, float seconds)
+    {
+        flashingType = type;
+        flashingTimer = seconds;
+    }
+
+    public void Draw(SpriteBatch spriteBatch)
     {
         //do nothing if disabled
         if (!Enabled) {
@@ -57,6 +79,15 @@ public class SpriteDict : IDrawable
         }
 
         //draw current sprite
-        dict[currentSprite].Draw(spriteBatch, gameTime, texture, Position);
+        dict[currentSprite].Draw(spriteBatch, texture, Position, GetColor());
+
+        flashingTimer -= (float) MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
+    }
+
+    private Color GetColor() {
+        if (flashingTimer <= 0f) {
+            return ColorData.White;
+        }
+        return flashingColors[flashingType][(int) (flashingTimer * FLASHING_RATE % flashingColors[flashingType].Count)];
     }
 }

--- a/MonoZelda/Sprites/SpriteDrawer.cs
+++ b/MonoZelda/Sprites/SpriteDrawer.cs
@@ -57,7 +57,7 @@ internal static class SpriteDrawer
         foreach (Drawable drawable in drawables)
         { 
             if (DrawGizmos || !drawable.isGizmo) {
-                drawable.iDrawable.Draw(spriteBatch, gameTime);
+                drawable.iDrawable.Draw(spriteBatch);
             }
         }
     }

--- a/MonoZelda/Sprites/SpriteLayer.cs
+++ b/MonoZelda/Sprites/SpriteLayer.cs
@@ -11,4 +11,5 @@ internal static class SpriteLayer
     public const int Transition = 50;
     public const int DoorLayer = 75;
     public const int HUD = 100;
+    public const int Gizmos = 200;
 }


### PR DESCRIPTION
Added flashing effects to SpriteDicts

Added new `IDrawable` type `BlankSprite` which is a flat color that can be dynamically resized and recolored. 
It has methods `FadeIn` and `FadeOut` which will fade the sprite in and out automatically based on a time parameter.

Integrated flashing effects for when:
- Link is damaged
- Enemies are damaged
- Items spawn
- Bomb blows up

Exchanged the curtains in `EnterDungeonScene` for `BlankSprites` so they are the correct size.

Added animation for bomb exploding, including multiple flashing clouds and a full-screen flash.