### PR TITLE
Fixes none error when throwing projectile before equipping any

### DIFF
--- a/MonoZelda/Link/Projectiles/ProjectileManager.cs
+++ b/MonoZelda/Link/Projectiles/ProjectileManager.cs
@@ -4,7 +4,6 @@ using Microsoft.Xna.Framework.Input;
 using MonoZelda.Collision;
 using MonoZelda.Controllers;
 using MonoZelda.Sprites;
-using System;
 using System.Collections.Generic;
 
 namespace MonoZelda.Link.Projectiles;
@@ -136,7 +135,7 @@ public class ProjectileManager
 
     public void fireEquippedProjectile(PlayerSpriteManager player)
     {
-        if (!hasRequiredResources(EquippedProjectile))
+        if (!hasRequiredResources(EquippedProjectile) || EquippedProjectile == ProjectileType.None)
         {
             return;
         }


### PR DESCRIPTION
When launching the game, Link hasn't equipped a projectile to fire. Because of this, attempting to fire causes issues. This PR aims to fix that. 