### PR TITLE
Calvin Long enemy levels

### DIFF
--- a/MonoZelda/Enemies/Enemy.cs
+++ b/MonoZelda/Enemies/Enemy.cs
@@ -35,6 +35,8 @@ namespace MonoZelda.Enemies
         public EnemyStateMachine StateMachine { get; set; }
         public EnemyStateMachine.Direction Direction { get; set; }
         private readonly Random rnd = new Random();
+        public float Timer {get; set; }
+        public int Level {get; set; }
 
         public virtual void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory, bool hasItem)
         {
@@ -45,6 +47,8 @@ namespace MonoZelda.Enemies
             CollisionController = collisionController;
             EnemyCollision = new EnemyCollisionManager(this, Width, Height);
             StateMachine = new EnemyStateMachine(enemyDict, itemFactory, hasItem);
+            Level = 3;
+            Timer = 0;
         }
 
         public virtual void ChangeDirection()
@@ -98,8 +102,27 @@ namespace MonoZelda.Enemies
             }
         }
 
+        public abstract void LevelOneBehavior();
+        public abstract void LevelTwoBehavior();
+        public abstract void LevelThreeBehavior();
+
+        public virtual void DecideBehavior(){
+            switch (Level){
+                case 1:
+                    LevelOneBehavior();
+                    break;
+                case 2:
+                    LevelTwoBehavior();
+                    break;
+                case 3:
+                    LevelThreeBehavior();
+                    break;
+            }
+        }
+
         public virtual void Update()
         {
+            Timer += (float)MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
             if (PixelsMoved >= TileSize)
             {
                 PixelsMoved = 0;
@@ -109,6 +132,7 @@ namespace MonoZelda.Enemies
             {
                 PixelsMoved++;
             }
+            DecideBehavior();
             CheckBounds();
             Pos = StateMachine.Update(this, Pos);
             EnemyCollision.Update(Width, Height, Pos);

--- a/MonoZelda/Enemies/Enemy.cs
+++ b/MonoZelda/Enemies/Enemy.cs
@@ -37,8 +37,9 @@ namespace MonoZelda.Enemies
         private readonly Random rnd = new Random();
         public float Timer {get; set; }
         public int Level {get; set; }
+        public EnemyFactory EnemyFactory {get; set;}
 
-        public virtual void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory, bool hasItem)
+        public virtual void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory, EnemyFactory enemyFactory, bool hasItem)
         {
             collisionController.AddCollidable(EnemyHitbox);
             EnemyHitbox.setSpriteDict(enemyDict);
@@ -47,7 +48,8 @@ namespace MonoZelda.Enemies
             CollisionController = collisionController;
             EnemyCollision = new EnemyCollisionManager(this, Width, Height);
             StateMachine = new EnemyStateMachine(enemyDict, itemFactory, hasItem);
-            Level = 3;
+            EnemyFactory = enemyFactory;
+            Level = 1;
             Timer = 0;
         }
 

--- a/MonoZelda/Enemies/Enemy.cs
+++ b/MonoZelda/Enemies/Enemy.cs
@@ -49,7 +49,7 @@ namespace MonoZelda.Enemies
             EnemyCollision = new EnemyCollisionManager(this, Width, Height);
             StateMachine = new EnemyStateMachine(enemyDict, itemFactory, hasItem);
             EnemyFactory = enemyFactory;
-            Level = 1;
+            Level = MonoZeldaGame.EnemyLevel;
             Timer = 0;
         }
 

--- a/MonoZelda/Enemies/EnemyClasses/Aquamentus.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Aquamentus.cs
@@ -32,10 +32,10 @@ namespace MonoZelda.Enemies.EnemyClasses
 
         }
 
-        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory, bool hasItem)
+        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory,EnemyFactory enemyFactory, bool hasItem)
         {
             EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), EnemyList.Aquamentus);
-            base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory, hasItem);
+            base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory,enemyFactory, hasItem);
             spawnPoint = spawnPosition;
             StateMachine.SetSprite("aquamentus_left");
             StateMachine.ChangeDirection(EnemyStateMachine.Direction.Left);
@@ -142,7 +142,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             if (stunTime == 0)
             {
                 Health -= damage;
-                if (Health == 0)
+                if (Health <= 0)
                 {
                     SoundManager.PlaySound("LOZ_Enemy_Die", false);
                     fireballs.ForEach(fireball => fireball.ProjectileCollide());

--- a/MonoZelda/Enemies/EnemyClasses/Aquamentus.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Aquamentus.cs
@@ -89,9 +89,9 @@ namespace MonoZelda.Enemies.EnemyClasses
             if (!projectileActive)
             {
                 projectileActive = true;
-                fireballs.Add(new AquamentusFireball(Pos, CollisionController, new Vector2(move.X,move.Y - 2)));
-                fireballs.Add(new AquamentusFireball(Pos, CollisionController, move));
-                fireballs.Add(new AquamentusFireball(Pos, CollisionController, new Vector2(move.X, move.Y + 2)));
+                fireballs.Add(new Fireball(Pos, CollisionController, new Vector2(move.X,move.Y - 2)));
+                fireballs.Add(new Fireball(Pos, CollisionController, move));
+                fireballs.Add(new Fireball(Pos, CollisionController, new Vector2(move.X, move.Y + 2)));
                 foreach (var projectile in fireballs)
                 {
                     projectileDictionary.Add(projectile, new EnemyProjectileCollisionManager(projectile));
@@ -156,6 +156,26 @@ namespace MonoZelda.Enemies.EnemyClasses
                     StateMachine.DamageFlash();
                 }
             }
+        }
+
+        public override void LevelOneBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelTwoBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelThreeBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void DecideBehavior()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Aquamentus.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Aquamentus.cs
@@ -82,7 +82,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             }
         }
 
-        public void CreateFireballs()
+        public override void LevelOneBehavior()
         {
             var move = PlayerState.Position.ToVector2() - Pos.ToVector2();
             move = Vector2.Divide(move, (float)Math.Sqrt(move.X * move.X + move.Y * move.Y)) * 6;
@@ -92,6 +92,42 @@ namespace MonoZelda.Enemies.EnemyClasses
                 fireballs.Add(new Fireball(Pos, CollisionController, new Vector2(move.X,move.Y - 2)));
                 fireballs.Add(new Fireball(Pos, CollisionController, move));
                 fireballs.Add(new Fireball(Pos, CollisionController, new Vector2(move.X, move.Y + 2)));
+                foreach (var projectile in fireballs)
+                {
+                    projectileDictionary.Add(projectile, new EnemyProjectileCollisionManager(projectile));
+                }
+            }
+        }
+
+        public override void LevelTwoBehavior()
+        {
+            var move = PlayerState.Position.ToVector2() - Pos.ToVector2();
+            move = Vector2.Divide(move, (float)Math.Sqrt(move.X * move.X + move.Y * move.Y)) * 6;
+            if (!projectileActive)
+            {
+                projectileActive = true;
+                fireballs.Add(new Fireball(Pos, CollisionController, new Vector2(move.X - 1,move.Y - 1)));
+                fireballs.Add(new Fireball(Pos, CollisionController, new Vector2(move.X - 1,move.Y)));
+                fireballs.Add(new Fireball(Pos, CollisionController, new Vector2(move.X - 1, move.Y + 1)));
+                foreach (var projectile in fireballs)
+                {
+                    projectileDictionary.Add(projectile, new EnemyProjectileCollisionManager(projectile));
+                }
+            }
+        }
+
+        public override void LevelThreeBehavior()
+        {
+            var move = PlayerState.Position.ToVector2() - Pos.ToVector2();
+            move = Vector2.Divide(move, (float)Math.Sqrt(move.X * move.X + move.Y * move.Y)) * 6;
+            if (!projectileActive)
+            {
+                projectileActive = true;
+                fireballs.Add(new Fireball(Pos, CollisionController, new Vector2(move.X - 1,move.Y - 2)));
+                fireballs.Add(new Fireball(Pos, CollisionController, new Vector2(move.X - 1,move.Y - 1)));
+                fireballs.Add(new Fireball(Pos, CollisionController, new Vector2(move.X - 1,move.Y)));
+                fireballs.Add(new Fireball(Pos, CollisionController, new Vector2(move.X - 1,move.Y + 1)));
+                fireballs.Add(new Fireball(Pos, CollisionController, new Vector2(move.X - 1,move.Y + 2)));
                 foreach (var projectile in fireballs)
                 {
                     projectileDictionary.Add(projectile, new EnemyProjectileCollisionManager(projectile));
@@ -121,7 +157,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             if (fireballs.Count == 0 && Health > 0)
             {
                 SoundManager.PlaySound("LOZ_Boss_Scream1", false);
-                CreateFireballs();
+                DecideBehavior();
                 StateMachine.SetSprite("aquamentus_left_mouthopen");
             }
             else
@@ -158,24 +194,5 @@ namespace MonoZelda.Enemies.EnemyClasses
             }
         }
 
-        public override void LevelOneBehavior()
-        {
-            throw new NotImplementedException();
-        }
-
-        public override void LevelTwoBehavior()
-        {
-            throw new NotImplementedException();
-        }
-
-        public override void LevelThreeBehavior()
-        {
-            throw new NotImplementedException();
-        }
-
-        public override void DecideBehavior()
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Dodongo.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Dodongo.cs
@@ -33,7 +33,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             Alive = true;
         }
 
-        public void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory, bool hasItem)
+        public void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory,EnemyFactory enemyFactory, bool hasItem)
         {
             this.collisionController = collisionController;
             EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), EnemyList.Dodongo);

--- a/MonoZelda/Enemies/EnemyClasses/Dodongo.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Dodongo.cs
@@ -107,5 +107,25 @@ namespace MonoZelda.Enemies.EnemyClasses
                 }
             }
         }
+
+        public override void LevelOneBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelTwoBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelThreeBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void DecideBehavior()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Gel.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Gel.cs
@@ -71,6 +71,26 @@ namespace MonoZelda.Enemies.EnemyClasses
         {
             base.TakeDamage(0, collisionDirection, 1);
         }
+
+        public override void LevelOneBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelTwoBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelThreeBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void DecideBehavior()
+        {
+            throw new NotImplementedException();
+        }
     }
 }
 

--- a/MonoZelda/Enemies/EnemyClasses/Gel.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Gel.cs
@@ -28,7 +28,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             Height = 32;
             Health = 1;
             Alive = true;
-            Level = 3;
+            Level = MonoZeldaGame.EnemyLevel;
         }
 
         public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory,EnemyFactory enemyFactory, bool hasItem)
@@ -36,6 +36,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             if(Level == 1){
                 EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), EnemyList.Gel);
                 base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory,enemyFactory, hasItem);
+                Level = 1;
                 spawnTimer = 0;
                 readyToJump = false;
                 StateMachine.SetSprite("gel_turquoise");

--- a/MonoZelda/Enemies/EnemyClasses/Goriya.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Goriya.cs
@@ -129,5 +129,25 @@ namespace MonoZelda.Enemies.EnemyClasses
             }
 
         }
+
+        public override void LevelOneBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelTwoBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelThreeBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void DecideBehavior()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Keese.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Keese.cs
@@ -12,7 +12,8 @@ namespace MonoZelda.Enemies.EnemyClasses
     {
         private readonly Random rnd = new();
         private double speedUpTimer;
-        private double dt;
+
+        private double timeToSpeedUp;
         private float speed;
 
         public Keese()
@@ -30,6 +31,9 @@ namespace MonoZelda.Enemies.EnemyClasses
             speed = 0;
             speedUpTimer = 0;
             StateMachine.SetSprite("keese_blue");
+            if(Level > 1){
+                StateMachine.SetSprite("keese_red");
+            }
         }
 
         public override void ChangeDirection()
@@ -63,11 +67,25 @@ namespace MonoZelda.Enemies.EnemyClasses
             }
             StateMachine.ChangeDirection(Direction);
         }
+        public override void LevelOneBehavior()
+        {
+            timeToSpeedUp = 2;
+        }
+
+        public override void LevelTwoBehavior()
+        {
+            timeToSpeedUp = 3;
+        }
+
+        public override void LevelThreeBehavior()
+        {
+            timeToSpeedUp = 4;
+        }
 
         public override void Update()
         {
             base.Update();
-            if (speedUpTimer < 2)
+            if (speedUpTimer < timeToSpeedUp)
             {
                 speedUpTimer += MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
                 speed++;
@@ -78,26 +96,6 @@ namespace MonoZelda.Enemies.EnemyClasses
         public override void TakeDamage(float stunTime, Direction collisionDirection, int damage)
         {
             base.TakeDamage(0, collisionDirection, 1);
-        }
-
-        public override void LevelOneBehavior()
-        {
-            throw new NotImplementedException();
-        }
-
-        public override void LevelTwoBehavior()
-        {
-            throw new NotImplementedException();
-        }
-
-        public override void LevelThreeBehavior()
-        {
-            throw new NotImplementedException();
-        }
-
-        public override void DecideBehavior()
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Keese.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Keese.cs
@@ -23,10 +23,10 @@ namespace MonoZelda.Enemies.EnemyClasses
             Alive = true;
         }
 
-        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory, bool hasItem)
+        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory,EnemyFactory enemyFactory, bool hasItem)
         {
             EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), EnemyList.Keese);
-            base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory, hasItem);
+            base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory,enemyFactory, hasItem);
             speed = 0;
             speedUpTimer = 0;
             StateMachine.SetSprite("keese_blue");

--- a/MonoZelda/Enemies/EnemyClasses/Keese.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Keese.cs
@@ -79,5 +79,25 @@ namespace MonoZelda.Enemies.EnemyClasses
         {
             base.TakeDamage(0, collisionDirection, 1);
         }
+
+        public override void LevelOneBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelTwoBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelThreeBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void DecideBehavior()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Oldman.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Oldman.cs
@@ -17,7 +17,7 @@ namespace MonoZelda.Enemies.EnemyClasses
 
         }
 
-        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory, bool hasItem)
+        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory,EnemyFactory enemyFactory, bool hasItem)
         {
             Pos = new Point(spawnPosition.X -32, spawnPosition.Y + 64);
             StateMachine = new EnemyStateMachine(enemyDict, itemFactory, hasItem);

--- a/MonoZelda/Enemies/EnemyClasses/Oldman.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Oldman.cs
@@ -34,5 +34,25 @@ namespace MonoZelda.Enemies.EnemyClasses
         {
             // oldman is immortal
         }
+
+        public override void LevelOneBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelTwoBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelThreeBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void DecideBehavior()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Rope.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Rope.cs
@@ -34,7 +34,7 @@ namespace MonoZelda.Enemies.EnemyClasses
             Alive = true;
         }
 
-        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory, bool hasItem)
+        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory,EnemyFactory enemyFactory, bool hasItem)
         {
             this.collisionController = collisionController;
             EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), EnemyList.Rope);

--- a/MonoZelda/Enemies/EnemyClasses/Rope.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Rope.cs
@@ -110,5 +110,25 @@ namespace MonoZelda.Enemies.EnemyClasses
                 }
             }
         }
+
+        public override void LevelOneBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelTwoBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelThreeBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void DecideBehavior()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Stalfos.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Stalfos.cs
@@ -25,10 +25,10 @@ namespace MonoZelda.Enemies.EnemyClasses
             Alive = true;
         }
 
-        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory, bool hasItem)
+        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory, EnemyFactory enemyFactory, bool hasItem)
         {
             EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), EnemyList.Stalfos);
-            base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory, hasItem);
+            base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory, enemyFactory, hasItem);
             StateMachine.SetSprite("stalfos");
         }
 
@@ -87,6 +87,14 @@ namespace MonoZelda.Enemies.EnemyClasses
             {
                 fireball.Key.Update(EnemyStateMachine.Direction.Left,Pos);
                 fireball.Value.Update();
+            }
+        }
+
+        public override void TakeDamage(float stunTime, Direction collisionDirection, int damage)
+        {
+            base.TakeDamage(stunTime, collisionDirection, damage);
+            if(Health <= 0){
+                fireballs.ForEach(fireball => fireball.ProjectileCollide());
             }
         }
     }

--- a/MonoZelda/Enemies/EnemyClasses/Stalfos.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Stalfos.cs
@@ -1,6 +1,10 @@
-﻿using Microsoft.Xna.Framework;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Xna.Framework;
 using MonoZelda.Collision;
 using MonoZelda.Controllers;
+using MonoZelda.Enemies.EnemyProjectiles;
 using MonoZelda.Items;
 using MonoZelda.Link;
 using MonoZelda.Sprites;
@@ -9,6 +13,10 @@ namespace MonoZelda.Enemies.EnemyClasses
 {
     public class Stalfos : Enemy
     {
+        private List<IEnemyProjectile> fireballs = new();
+        private Dictionary<IEnemyProjectile, EnemyProjectileCollisionManager> projectileDictionary = new();
+        private bool projActive = false;
+        
         public Stalfos()
         {
             Width = 48;
@@ -22,6 +30,64 @@ namespace MonoZelda.Enemies.EnemyClasses
             EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), EnemyList.Stalfos);
             base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory, hasItem);
             StateMachine.SetSprite("stalfos");
+        }
+
+        public override void LevelOneBehavior()
+        {
+            //default skeleton
+        }
+
+        public override void LevelTwoBehavior()
+        {
+            if(!projActive && Timer >= 3){
+                projActive = true;
+                Timer = 0;
+                var move = PlayerState.Position.ToVector2() - Pos.ToVector2();
+                move = Vector2.Divide(move, (float)Math.Sqrt(move.X * move.X + move.Y * move.Y)) * 6;
+                fireballs.Add(new Fireball(Pos, CollisionController, move));
+                    foreach (var projectile in fireballs)
+                    {
+                        projectileDictionary.Add(projectile, new EnemyProjectileCollisionManager(projectile));
+                    }
+            }
+            fireballUpdate();
+        }
+
+        public override void LevelThreeBehavior()
+        {
+            if(!projActive && Timer >= 3){
+                projActive = true;
+                Timer = 0;
+                var move = PlayerState.Position.ToVector2() - Pos.ToVector2();
+                move = Vector2.Divide(move, (float)Math.Sqrt(move.X * move.X + move.Y * move.Y)) * 6;
+                fireballs.Add(new Fireball(Pos, CollisionController, new Vector2(move.X,move.Y - 1)));
+                fireballs.Add(new Fireball(Pos, CollisionController, move));
+                foreach (var projectile in fireballs)
+                {
+                    projectileDictionary.Add(projectile, new EnemyProjectileCollisionManager(projectile));
+                }
+            }
+            fireballUpdate();
+        }
+
+        public void fireballUpdate(){
+            var tempActive = false;
+            foreach (var entry in projectileDictionary)
+            {
+                if (entry.Key.Active)
+                {
+                    tempActive = true;
+                }else{
+                    fireballs.Remove(entry.Key);
+                    projectileDictionary.Remove(entry.Key);
+                }
+            }
+            projActive = tempActive;
+            foreach (KeyValuePair<IEnemyProjectile, EnemyProjectileCollisionManager> fireball in projectileDictionary)
+            {
+                fireball.Key.Update(EnemyStateMachine.Direction.Left,Pos);
+                fireball.Value.Update();
+            }
         }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Trap.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Trap.cs
@@ -22,10 +22,10 @@ namespace MonoZelda.Enemies.EnemyClasses
             Alive = true;
         }
 
-        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory, bool hasItem)
+        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory,EnemyFactory enemyFactory, bool hasItem)
         {
             EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), EnemyList.Trap);
-            base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory, hasItem);
+            base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory,enemyFactory, hasItem);
             attacking = false;
             retreating = false;
             StateMachine.SetSprite("bladetrap");

--- a/MonoZelda/Enemies/EnemyClasses/Trap.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Trap.cs
@@ -119,5 +119,25 @@ namespace MonoZelda.Enemies.EnemyClasses
         {
             //cannot take damage
         }
+
+        public override void LevelOneBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelTwoBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelThreeBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void DecideBehavior()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Wallmaster.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Wallmaster.cs
@@ -34,10 +34,10 @@ namespace MonoZelda.Enemies.EnemyClasses
             Alive = true;
         }
 
-        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory, bool hasItem)
+        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory,EnemyFactory enemyFactory, bool hasItem)
         {
             EnemyHitbox = new EnemyCollidable(new Rectangle(-100, -100, Width, Height), EnemyList.Wallmaster);
-            base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory, hasItem);
+            base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory,enemyFactory, hasItem);
             spawned = true;
             timer = (float)(rnd.NextDouble()  - rnd.Next(0,2))*-1;
             Pos = new Point(-100, -100);

--- a/MonoZelda/Enemies/EnemyClasses/Wallmaster.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Wallmaster.cs
@@ -223,5 +223,25 @@ namespace MonoZelda.Enemies.EnemyClasses
                 Health = 2;
             }
         }
+
+        public override void LevelOneBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelTwoBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelThreeBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void DecideBehavior()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Wallmaster.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Wallmaster.cs
@@ -238,10 +238,5 @@ namespace MonoZelda.Enemies.EnemyClasses
         {
             throw new NotImplementedException();
         }
-
-        public override void DecideBehavior()
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/MonoZelda/Enemies/EnemyClasses/Zol.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Zol.cs
@@ -26,10 +26,10 @@ namespace MonoZelda.Enemies.EnemyClasses
             throw new NotImplementedException();
         }
 
-        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory, bool hasItem)
+        public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory,EnemyFactory enemyFactory, bool hasItem)
         {
             EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), EnemyList.Zol);
-            base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory, hasItem);
+            base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory,enemyFactory, hasItem);
             readyToJump = false;
             StateMachine.SetSprite("zol_brown");
         }

--- a/MonoZelda/Enemies/EnemyClasses/Zol.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Zol.cs
@@ -21,12 +21,32 @@ namespace MonoZelda.Enemies.EnemyClasses
             Alive = true;
         }
 
+        public override void DecideBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
         public override void EnemySpawn(SpriteDict enemyDict, Point spawnPosition, CollisionController collisionController, ItemFactory itemFactory, bool hasItem)
         {
             EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), EnemyList.Zol);
             base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory, hasItem);
             readyToJump = false;
             StateMachine.SetSprite("zol_brown");
+        }
+
+        public override void LevelOneBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelThreeBehavior()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void LevelTwoBehavior()
+        {
+            throw new NotImplementedException();
         }
 
         public override void Update()

--- a/MonoZelda/Enemies/EnemyClasses/Zol.cs
+++ b/MonoZelda/Enemies/EnemyClasses/Zol.cs
@@ -31,7 +31,17 @@ namespace MonoZelda.Enemies.EnemyClasses
             EnemyHitbox = new EnemyCollidable(new Rectangle(spawnPosition.X, spawnPosition.Y, Width, Height), EnemyList.Zol);
             base.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory,enemyFactory, hasItem);
             readyToJump = false;
-            StateMachine.SetSprite("zol_brown");
+            switch (MonoZeldaGame.EnemyLevel){
+                    case 1:
+                        StateMachine.SetSprite("zol_turquoise");
+                        break;
+                    case 2:
+                        StateMachine.SetSprite("zol_turquoise");
+                        break;
+                    case 3:
+                        StateMachine.SetSprite("zol_black");
+                        break;
+                }
         }
 
         public override void LevelOneBehavior()

--- a/MonoZelda/Enemies/EnemyFactory.cs
+++ b/MonoZelda/Enemies/EnemyFactory.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework;
 using MonoZelda.Items;
 using MonoZelda.Link;
 using MonoZelda.Sprites;
+using MonoZelda.Enemies.EnemyClasses;
 
 namespace MonoZelda.Enemies
 {
@@ -16,12 +17,15 @@ namespace MonoZelda.Enemies
             this.collisionController = collisionController;
         }
 
-        public Enemy CreateEnemy(EnemyList enemyName, Point spawnPosition, ItemFactory itemFactory, bool hasKey)
+        public Enemy CreateEnemy(EnemyList enemyName, Point spawnPosition, ItemFactory itemFactory, EnemyFactory enemyFactory,bool hasKey)
         {
             var enemyDict = new SpriteDict(SpriteType.Enemies, 0, new Point(0, 0));
             var enemyType = Type.GetType($"MonoZelda.Enemies.EnemyClasses.{enemyName}");
             Enemy enemy = (Enemy)Activator.CreateInstance(enemyType);
-            enemy.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory, hasKey);
+            if(enemyType == typeof(Gel) && hasKey){
+                enemy.Level = 1;
+            }
+            enemy.EnemySpawn(enemyDict, spawnPosition, collisionController, itemFactory, enemyFactory, hasKey);
 
             return enemy;
         }

--- a/MonoZelda/Enemies/EnemyProjectiles/Fireball.cs
+++ b/MonoZelda/Enemies/EnemyProjectiles/Fireball.cs
@@ -6,7 +6,7 @@ using Vector2 = Microsoft.Xna.Framework.Vector2;
 
 namespace MonoZelda.Enemies.EnemyProjectiles
 {
-    public class AquamentusFireball : IEnemyProjectile
+    public class Fireball : IEnemyProjectile
     {
         public EnemyProjectileCollidable ProjectileHitbox { get; set; }
         public Point Pos { get; set; }
@@ -18,7 +18,7 @@ namespace MonoZelda.Enemies.EnemyProjectiles
         public bool Active { get; set; }
         private Vector2 move;
 
-        public AquamentusFireball(Point pos, CollisionController collisionController, Vector2 C)
+        public Fireball(Point pos, CollisionController collisionController, Vector2 C)
         {
             Pos = pos;
             originalPos = pos;

--- a/MonoZelda/Enemies/EnemyProjectiles/Fireball.cs
+++ b/MonoZelda/Enemies/EnemyProjectiles/Fireball.cs
@@ -10,7 +10,6 @@ namespace MonoZelda.Enemies.EnemyProjectiles
     {
         public EnemyProjectileCollidable ProjectileHitbox { get; set; }
         public Point Pos { get; set; }
-        private Point originalPos;
 
         private CollisionController collisionController;
         public SpriteDict FireballSpriteDict { get; private set; }
@@ -21,7 +20,6 @@ namespace MonoZelda.Enemies.EnemyProjectiles
         public Fireball(Point pos, CollisionController collisionController, Vector2 C)
         {
             Pos = pos;
-            originalPos = pos;
             FireballSpriteDict = new(SpriteType.Enemies, 0, new Point(100, 100));
             FireballSpriteDict.SetSprite("fireball");
             ProjectileHitbox = new EnemyProjectileCollidable(new Rectangle(pos.X, pos.Y, 30, 30));

--- a/MonoZelda/Enemies/EnemyProjectiles/GoriyaBoomerang.cs
+++ b/MonoZelda/Enemies/EnemyProjectiles/GoriyaBoomerang.cs
@@ -13,7 +13,6 @@ namespace MonoZelda.Enemies.GoriyaFolder
         public SpriteDict BoomerangSpriteDict { get; private set; }
         public bool Active { get; set; }
         public EnemyProjectileCollidable ProjectileHitbox { get; set; }
-        private EnemyStateMachine.Direction attackDirection;
         private float velocity = 400;
         private float attackTimer;
         private float dt;
@@ -62,7 +61,6 @@ namespace MonoZelda.Enemies.GoriyaFolder
 
         public void Update (EnemyStateMachine.Direction direction, Point enemyPos)
         {
-            attackDirection = direction;
             dt = (float)MonoZeldaGame.GameTime.ElapsedGameTime.TotalSeconds;
             attackTimer += dt;
             var pos = new Vector2();

--- a/MonoZelda/MonoZeldaGame.cs
+++ b/MonoZelda/MonoZeldaGame.cs
@@ -140,7 +140,7 @@ public class MonoZeldaGame : Game, ISaveable
         if (scene is MainMenuScene)
         {
             SoundManager.StopSound("LOZ_Intro");
-            LoadDungeon("Room1");
+            LoadDungeon("RoomTest");
         }
     }
 

--- a/MonoZelda/MonoZeldaGame.cs
+++ b/MonoZelda/MonoZeldaGame.cs
@@ -36,8 +36,12 @@ public class MonoZeldaGame : Game, ISaveable
 
     private IScene scene;
 
+    public static int EnemyLevel {get; set;}
+
     public MonoZeldaGame()
     {
+        EnemyLevel = 3;
+
         graphicsDeviceManager = new GraphicsDeviceManager(this);
         Content.RootDirectory = "Content";
         IsMouseVisible = true;

--- a/MonoZelda/Scenes/RoomScene.cs
+++ b/MonoZelda/Scenes/RoomScene.cs
@@ -138,7 +138,7 @@ public class RoomScene : Scene
         foreach(var enemySpawn in room.GetEnemySpawns())
         {
             var enemy = enemyFactory.CreateEnemy(enemySpawn.EnemyType,
-                new Point(enemySpawn.Position.X + 32, enemySpawn.Position.Y + 32), itemFactory, enemySpawn.HasKey);
+                new Point(enemySpawn.Position.X + 32, enemySpawn.Position.Y + 32), itemFactory,enemyFactory, enemySpawn.HasKey);
             enemies.Add(enemy);
             enemySpawnPoints.Add(enemy,enemySpawn);
         }


### PR DESCRIPTION
### NEW

- Added enemy levels
- Enemy behaviors change with levels

### NEW BEHAVIORS
Level 1 is default behaviors

**STALFOS**
- Level 2: Shoots one fireball every three seconds
- Level 3: Shoots two fireballs every three seconds

 **GORIYA**
- Level 2: Shoots additional boomerang behind itself
- Level 3: Shoots boomerangs in all four directions

 **GEL**
- Level 2: Spawns as Zol instead of Gel, when Zol is killed a Gel is spawned
- Level 3: Spawns as Zol instead of Gel, when Zol is killed three Gels spawn

 **KEESE**
- Level 2: Speeds up more overtime
- Level 3: Speeds up even more overtime

**AQUAMENTUS**
- Level 2: Shoots faster fireballs with a tighter spread.
- Level 3: Shoots 5 faster fireballs with a tighter spread.

### NOTES

- Currently enemyLevel is just a public static int in MonoZeldaGame, could probably put it somewhere else.
- Still undecided what determines enemy levels, I'm in favor of leveling up the enemies every time a boss is defeated in infinite mode (every 5/10 levels maybe?).